### PR TITLE
Options page at /accounts/[uuid]/options + account-aware nav

### DIFF
--- a/app/accounts/[uuid]/layout.tsx
+++ b/app/accounts/[uuid]/layout.tsx
@@ -1,0 +1,16 @@
+import { notFound } from "next/navigation";
+import { getDb } from "@/lib/db/connection";
+import { getAccountByUuid } from "@/lib/db/repos/accounts";
+
+export default async function AccountLayout({
+  params,
+  children,
+}: {
+  params: Promise<{ uuid: string }>;
+  children: React.ReactNode;
+}) {
+  const { uuid } = await params;
+  const db = getDb();
+  if (!getAccountByUuid(db, uuid)) notFound();
+  return <>{children}</>;
+}

--- a/app/accounts/[uuid]/options/page.tsx
+++ b/app/accounts/[uuid]/options/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
 import { loadAccountOptionsView } from "@/lib/server/account";
+import { getAccountTabFlags } from "@/lib/server/accountTabs";
+import { AccountTabs } from "@/app/components/AccountTabs";
 import { AttentionBanner } from "@/app/components/AttentionBanner";
 import { SummaryStrip } from "@/app/components/SummaryStrip";
 import { NavCard } from "@/app/components/NavCard";
@@ -22,20 +24,28 @@ export default async function AccountOptionsPage({
   params: Promise<{ uuid: string }>;
 }) {
   const { uuid } = await params;
-  const data = await loadAccountOptionsView(uuid);
+  const [data, flags] = await Promise.all([
+    loadAccountOptionsView(uuid),
+    getAccountTabFlags(uuid),
+  ]);
 
   if (data === null) notFound();
 
+  const tabFlags = flags ?? { showOptions: true, showTrades: true };
+
   if (data.kind === "no-data") {
     return (
-      <main className="min-h-screen p-6 max-w-7xl mx-auto">
-        <header className="rounded-lg border border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-5 py-4 mb-4">
-          <div className="text-xl font-bold">{data.account.label}</div>
-          <div className="text-xs text-gray-500 dark:text-gray-400">
-            No transactions or position snapshots yet for this account.
-          </div>
-        </header>
-      </main>
+      <>
+        <AccountTabs uuid={uuid} flags={tabFlags} active="options" />
+        <main className="min-h-screen p-6 max-w-7xl mx-auto">
+          <header className="rounded-lg border border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-5 py-4 mb-4">
+            <div className="text-xl font-bold">{data.account.label}</div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              No transactions or position snapshots yet for this account.
+            </div>
+          </header>
+        </main>
+      </>
     );
   }
 
@@ -43,6 +53,8 @@ export default async function AccountOptionsPage({
   const asOfDate = state.navSeries.at(-1)?.date ?? state.config.seedDate;
 
   return (
+    <>
+    <AccountTabs uuid={uuid} flags={tabFlags} active="options" />
     <main className="min-h-screen p-6 max-w-7xl mx-auto">
       <header className="rounded-lg border border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-5 py-4 mb-4 flex items-baseline justify-between">
         <div>
@@ -107,5 +119,6 @@ export default async function AccountOptionsPage({
         </div>
       )}
     </main>
+    </>
   );
 }

--- a/app/accounts/[uuid]/options/page.tsx
+++ b/app/accounts/[uuid]/options/page.tsx
@@ -1,0 +1,111 @@
+import { notFound } from "next/navigation";
+import { loadAccountOptionsView } from "@/lib/server/account";
+import { AttentionBanner } from "@/app/components/AttentionBanner";
+import { SummaryStrip } from "@/app/components/SummaryStrip";
+import { NavCard } from "@/app/components/NavCard";
+import { PremiumsCard } from "@/app/components/PremiumsCard";
+import { OpenPositionsCard } from "@/app/components/OpenPositionsCard";
+import { TransactionLogCard } from "@/app/components/TransactionLogCard";
+import { TradeHistoryCard } from "@/app/components/TradeHistoryCard";
+import { ReturnMetricsCard } from "@/app/components/ReturnMetricsCard";
+import { OutcomesCard } from "@/app/components/OutcomesCard";
+import { PremiumByTickerCard } from "@/app/components/PremiumByTickerCard";
+import { CashYieldCard } from "@/app/components/CashYieldCard";
+import { CapitalAtRiskCard } from "@/app/components/CapitalAtRiskCard";
+import { MarkToMarketCard } from "@/app/components/MarkToMarketCard";
+
+export const dynamic = "force-dynamic";
+
+export default async function AccountOptionsPage({
+  params,
+}: {
+  params: Promise<{ uuid: string }>;
+}) {
+  const { uuid } = await params;
+  const data = await loadAccountOptionsView(uuid);
+
+  if (data === null) notFound();
+
+  if (data.kind === "no-data") {
+    return (
+      <main className="min-h-screen p-6 max-w-7xl mx-auto">
+        <header className="rounded-lg border border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-5 py-4 mb-4">
+          <div className="text-xl font-bold">{data.account.label}</div>
+          <div className="text-xs text-gray-500 dark:text-gray-400">
+            No transactions or position snapshots yet for this account.
+          </div>
+        </header>
+      </main>
+    );
+  }
+
+  const { account, state, sourceFiles, loadedAt, markToMarket } = data;
+  const asOfDate = state.navSeries.at(-1)?.date ?? state.config.seedDate;
+
+  return (
+    <main className="min-h-screen p-6 max-w-7xl mx-auto">
+      <header className="rounded-lg border border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-5 py-4 mb-4 flex items-baseline justify-between">
+        <div>
+          <div className="text-xl font-bold">{account.label} · Options</div>
+          <div className="text-xs text-gray-500 dark:text-gray-400">
+            Seed ${state.config.seedValue.toLocaleString()} on{" "}
+            {state.config.seedDate} · Data through {asOfDate} · Source:{" "}
+            <code className="bg-gray-100 dark:bg-neutral-800 px-1 rounded">
+              {sourceFiles.transactions.length} transactions ·{" "}
+              {sourceFiles.positions.length} positions
+            </code>
+          </div>
+        </div>
+        <div className="text-xs text-gray-500 dark:text-gray-400">
+          Last refresh {new Date(loadedAt).toLocaleTimeString()}
+        </div>
+      </header>
+
+      <AttentionBanner warnings={state.warnings} />
+
+      <SummaryStrip state={state} markToMarket={markToMarket} />
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+        <div className="md:col-span-2">
+          <NavCard state={state} />
+        </div>
+        <div>
+          <PremiumsCard state={state} />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+        <OpenPositionsCard state={state} asOfDate={asOfDate} />
+        <TransactionLogCard transactions={state.transactions} />
+      </div>
+
+      <div className="mb-4">
+        <TradeHistoryCard state={state} />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+        <div className="md:col-span-2">
+          <ReturnMetricsCard state={state} />
+        </div>
+        <div>
+          <OutcomesCard state={state} />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+        <PremiumByTickerCard state={state} />
+        <CashYieldCard state={state} />
+      </div>
+
+      <div className="mb-4">
+        <CapitalAtRiskCard state={state} />
+      </div>
+
+      {markToMarket !== null && markToMarket.rows.length > 0 && (
+        <div className="mb-4">
+          <MarkToMarketCard markToMarket={markToMarket} />
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/components/AccountPicker.tsx
+++ b/app/components/AccountPicker.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import type { Account } from "@/lib/db/repos/accounts";
+
+type Props = { accounts: Account[]; currentUuid?: string };
+
+export function AccountPicker({ accounts, currentUuid }: Props) {
+  const router = useRouter();
+  return (
+    <select
+      value={currentUuid ?? ""}
+      onChange={(e) => {
+        const uuid = e.target.value;
+        if (uuid) router.push(`/accounts/${uuid}/options`);
+        else router.push("/");
+      }}
+      className="text-sm bg-transparent border border-gray-300 dark:border-neutral-700 rounded px-2 py-1 text-gray-700 dark:text-gray-200"
+    >
+      <option value="">All accounts</option>
+      {accounts.map((a) => (
+        <option key={a.uuid} value={a.uuid}>
+          {a.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/app/components/AccountTabs.tsx
+++ b/app/components/AccountTabs.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+
+export type AccountTabFlags = {
+  showOptions: boolean;
+  showTrades: boolean;
+};
+
+type Props = {
+  uuid: string;
+  flags: AccountTabFlags;
+  active?: "overview" | "options" | "trades" | "transactions";
+};
+
+const ALL_TABS = [
+  { key: "overview" as const, label: "Overview", path: "overview" },
+  { key: "options" as const, label: "Options", path: "options" },
+  { key: "trades" as const, label: "Trades", path: "trades" },
+  { key: "transactions" as const, label: "Transactions", path: "transactions" },
+];
+
+export function AccountTabs({ uuid, flags, active }: Props) {
+  const tabs = ALL_TABS.filter((t) => {
+    if (t.key === "options") return flags.showOptions;
+    if (t.key === "trades") return flags.showTrades;
+    return true;
+  });
+  return (
+    <nav className="border-b border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+      <div className="max-w-7xl mx-auto px-6 py-2 flex items-center gap-4">
+        {tabs.map((t) => {
+          const isActive = active === t.key;
+          return (
+            <Link
+              key={t.key}
+              href={`/accounts/${uuid}/${t.path}`}
+              className={`text-sm ${
+                isActive
+                  ? "font-semibold text-gray-900 dark:text-gray-100"
+                  : "text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+              }`}
+            >
+              {t.label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/app/components/AppNav.tsx
+++ b/app/components/AppNav.tsx
@@ -1,6 +1,10 @@
 import Link from "next/link";
+import type { Account } from "@/lib/db/repos/accounts";
+import { AccountPicker } from "@/app/components/AccountPicker";
 
-export function AppNav() {
+type Props = { accounts: Account[]; currentUuid?: string };
+
+export function AppNav({ accounts, currentUuid }: Props) {
   return (
     <nav className="border-b border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
       <div className="max-w-7xl mx-auto px-6 py-3 flex items-center gap-6">
@@ -10,6 +14,9 @@ export function AppNav() {
         >
           Schwab Lens
         </Link>
+        {accounts.length > 0 && (
+          <AccountPicker accounts={accounts} currentUuid={currentUuid} />
+        )}
       </div>
     </nav>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,21 +1,23 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { AppNav } from "@/app/components/AppNav";
+import { loadAccounts } from "@/lib/server/home";
 
 export const metadata: Metadata = {
   title: "Schwab Lens",
   description: "Local-first read-only Schwab brokerage dashboards",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const accounts = await loadAccounts();
   return (
     <html lang="en" className="h-full antialiased">
       <body className="min-h-full flex flex-col">
-        <AppNav />
+        <AppNav accounts={accounts} />
         {children}
       </body>
     </html>

--- a/lib/model/fromDb.ts
+++ b/lib/model/fromDb.ts
@@ -1,0 +1,125 @@
+import type {
+  Action,
+  RawCsvRow,
+  Transaction,
+} from "@/lib/csv/types";
+import type { PositionSnapshotRow } from "@/lib/db/repos/positionSnapshots";
+import type { TransactionRow } from "@/lib/db/repos/transactions";
+import type {
+  PositionsSnapshot,
+  SnapshotShare,
+  SnapshotOption,
+} from "@/lib/positions/types";
+import { parseOptionSymbol } from "@/lib/schwab/optionSymbol";
+
+const ACTION_MAP: Record<string, Action> = {
+  BUY: "Buy",
+  SELL: "Sell",
+  BUY_TO_OPEN: "Buy",
+  SELL_TO_OPEN: "SellToOpen",
+  BUY_TO_CLOSE: "BuyToClose",
+  SELL_TO_CLOSE: "Sell",
+  ASSIGNMENT: "Assigned",
+  EXERCISE: "Assigned",
+  EXPIRATION: "Expired",
+  DIVIDEND: "QualifiedDividend",
+  INTEREST: "BankInterest",
+  FEE: "ServiceFee",
+  JOURNAL: "Journal",
+  TRANSFER_IN: "Journal",
+  TRANSFER_OUT: "WireSent",
+};
+
+export function actionFromCanonical(canonical: string, _raw: string): Action {
+  return ACTION_MAP[canonical] ?? "Unknown";
+}
+
+export function transactionFromRow(row: TransactionRow): Transaction {
+  const action = actionFromCanonical(row.action_canonical, row.action_raw);
+  const optionLeg = parseOptionSymbol(row.symbol);
+  const tx: Transaction = {
+    tradeDate: row.trade_date,
+    action,
+    quantity: row.quantity ?? 0,
+    fees: row.fees ?? 0,
+    amount: row.amount,
+    raw: parseRaw(row.raw),
+    rawAction: row.action_raw,
+  };
+  if (row.price !== null) tx.price = row.price;
+  if (optionLeg) {
+    tx.option = optionLeg;
+  } else if (row.symbol) {
+    tx.ticker = row.symbol;
+  }
+  return tx;
+}
+
+function parseRaw(raw: string): RawCsvRow {
+  try {
+    return JSON.parse(raw) as RawCsvRow;
+  } catch {
+    return {
+      Date: "",
+      Action: "",
+      Symbol: "",
+      Description: "",
+      Quantity: "",
+      Price: "",
+      "Fees & Comm": "",
+      Amount: "",
+    };
+  }
+}
+
+export function positionsSnapshotFromRows(
+  asOf: string,
+  rows: PositionSnapshotRow[],
+): PositionsSnapshot {
+  const shares: SnapshotShare[] = [];
+  const options: SnapshotOption[] = [];
+  let cash = 0;
+  let totalValue = 0;
+
+  for (const row of rows) {
+    const mv = row.market_value ?? 0;
+    totalValue += mv;
+    if (row.asset_type === "cash") {
+      cash += mv;
+      continue;
+    }
+    if (row.asset_type === "option") {
+      const leg = parseOptionSymbol(row.symbol);
+      if (!leg) continue;
+      options.push({
+        underlying: leg.ticker,
+        expiry: leg.expiry,
+        strike: leg.strike,
+        callPut: leg.type === "Call" ? "C" : "P",
+        quantity: row.quantity ?? 0,
+        price: row.price ?? 0,
+        marketValue: mv,
+        delta: null,
+        theta: null,
+        intrinsicValue: null,
+      });
+      continue;
+    }
+    shares.push({
+      ticker: row.symbol,
+      quantity: row.quantity ?? 0,
+      price: row.price ?? 0,
+      marketValue: mv,
+      costBasis: row.cost_basis ?? 0,
+    });
+  }
+
+  return {
+    asOf,
+    cash,
+    totalValue,
+    shares,
+    options,
+    sourceFile: rows[0]?.source_file ?? "",
+  };
+}

--- a/lib/model/fromDb.ts
+++ b/lib/model/fromDb.ts
@@ -30,12 +30,12 @@ const ACTION_MAP: Record<string, Action> = {
   TRANSFER_OUT: "WireSent",
 };
 
-export function actionFromCanonical(canonical: string, _raw: string): Action {
+export function actionFromCanonical(canonical: string): Action {
   return ACTION_MAP[canonical] ?? "Unknown";
 }
 
 export function transactionFromRow(row: TransactionRow): Transaction {
-  const action = actionFromCanonical(row.action_canonical, row.action_raw);
+  const action = actionFromCanonical(row.action_canonical);
   const optionLeg = parseOptionSymbol(row.symbol);
   const tx: Transaction = {
     tradeDate: row.trade_date,

--- a/lib/schwab/optionSymbol.ts
+++ b/lib/schwab/optionSymbol.ts
@@ -1,0 +1,17 @@
+import type { OptionLeg } from "@/lib/csv/types";
+
+const PATTERN =
+  /^([A-Z][A-Z0-9.]*)\s+(\d{2})\/(\d{2})\/(\d{4})\s+([0-9]+(?:\.[0-9]+)?)\s+([CP])$/;
+
+export function parseOptionSymbol(symbol: string | null): OptionLeg | null {
+  if (!symbol) return null;
+  const match = symbol.trim().match(PATTERN);
+  if (!match) return null;
+  const [, ticker, mm, dd, yyyy, strike, cp] = match;
+  return {
+    ticker,
+    expiry: `${yyyy}-${mm}-${dd}`,
+    strike: Number(strike),
+    type: cp === "C" ? "Call" : "Put",
+  };
+}

--- a/lib/server/account.ts
+++ b/lib/server/account.ts
@@ -11,14 +11,22 @@ import {
   getSnapshotByDate,
 } from "@/lib/db/repos/positionSnapshots";
 import { getBoolean } from "@/lib/db/repos/settings";
+import { fetchQuotes, type Quote } from "@/lib/market/quotes";
+import { loadHistoricalCloses } from "@/lib/market/historical";
 import {
   positionsSnapshotFromRows,
   transactionFromRow,
 } from "@/lib/model/fromDb";
+import {
+  computeMarkToMarket,
+  type MarkToMarket,
+} from "@/lib/model/metrics/mark_to_market";
+import { computePortfolioValueSeries } from "@/lib/model/metrics/portfolio_value";
 import { buildPortfolio } from "@/lib/model/portfolio";
 import { chooseSeed } from "@/lib/positions/seed";
-import type { Config, PortfolioState } from "@/lib/model/types";
+import type { Config, PortfolioState, Seed } from "@/lib/model/types";
 import type { PositionsSnapshot } from "@/lib/positions/types";
+import { yesterdayInET } from "@/lib/util/dates";
 
 export type AccountOptionsView =
   | {
@@ -28,11 +36,13 @@ export type AccountOptionsView =
       sourceFiles: { transactions: string[]; positions: string[] };
       loadedAt: string;
       latestSnapshot: PositionsSnapshot | null;
+      markToMarket: MarkToMarket | null;
     }
   | { kind: "no-data"; account: Account };
 
 export interface LoadAccountOptionsViewOpts {
   db?: Database.Database;
+  includeMarketData?: boolean;
 }
 
 export async function loadAccountOptionsView(
@@ -82,6 +92,109 @@ export async function loadAccountOptionsView(
 
   const state = buildPortfolio(transactions, config, seed);
 
+  let markToMarket: MarkToMarket | null = null;
+  const includeMarket = (opts.includeMarketData ?? true) && marketDataEnabled;
+
+  if (includeMarket) {
+    const heldTickers = collectHeldTickers(state, seed);
+    const endDate = yesterdayInET();
+
+    if (heldTickers.length > 0 && endDate >= seed.asOf) {
+      const historicalCloses: Record<string, Record<string, number>> = {};
+      const fetchFailures: Array<{ ticker: string; reason: string }> = [];
+
+      for (const ticker of heldTickers) {
+        const res = await loadHistoricalCloses(ticker, seed.asOf, endDate);
+        if (res.kind === "ok") {
+          const byDate: Record<string, number> = {};
+          for (const { date, close } of res.closes) byDate[date] = close;
+          historicalCloses[ticker] = byDate;
+        } else {
+          fetchFailures.push({ ticker, reason: res.message });
+        }
+      }
+
+      const pv = computePortfolioValueSeries(
+        state,
+        seed,
+        historicalCloses,
+        endDate,
+      );
+      state.portfolioValueSeries = pv.series;
+
+      const missingSet = new Set<string>([
+        ...fetchFailures.map((f) => f.ticker),
+        ...pv.missingTickers,
+      ]);
+      const reasonByTicker = new Map(
+        fetchFailures.map((f) => [f.ticker, f.reason]),
+      );
+      for (const ticker of Array.from(missingSet).sort()) {
+        state.warnings.push({
+          kind: "MissingHistoricalPrices",
+          ticker,
+          reason:
+            reasonByTicker.get(ticker) ??
+            "No historical close data available for one or more dates.",
+        });
+      }
+    }
+
+    if (typeof config.benchmark === "string" && config.benchmark.length > 0) {
+      const ticker = config.benchmark;
+      const res = await loadHistoricalCloses(ticker, seed.asOf, endDate);
+      if (res.kind === "ok" && res.closes.length >= 2) {
+        const baseline = res.closes[0].close;
+        if (baseline > 0 && Number.isFinite(baseline)) {
+          state.benchmarkSeries = res.closes.map(({ date, close }) => ({
+            date,
+            nav: state.config.seedValue * (close / baseline),
+          }));
+          state.benchmarkTicker = ticker;
+        } else {
+          state.warnings.push({
+            kind: "MissingHistoricalPrices",
+            ticker,
+            reason: "Baseline close is zero or invalid.",
+          });
+        }
+      } else {
+        const reason =
+          res.kind === "error"
+            ? res.message
+            : "Insufficient historical data to render a benchmark line.";
+        state.warnings.push({
+          kind: "MissingHistoricalPrices",
+          ticker,
+          reason,
+        });
+      }
+    }
+
+    if (state.openSharePositions.length > 0 || latestSnapshot !== null) {
+      const snapSymbols = new Set(
+        (latestSnapshot?.shares ?? []).map((s) => s.ticker),
+      );
+      const missing = state.openSharePositions
+        .map((s) => s.ticker)
+        .filter((t) => !snapSymbols.has(t));
+
+      const quoteMap: Record<string, Quote | null> = {};
+      if (missing.length > 0) {
+        const results = await fetchQuotes(missing);
+        for (const r of results) {
+          if (r.kind === "ok") quoteMap[r.quote.ticker] = r.quote;
+        }
+        for (const t of missing) if (!(t in quoteMap)) quoteMap[t] = null;
+      }
+      markToMarket = computeMarkToMarket(
+        state,
+        quoteMap,
+        latestSnapshot ?? undefined,
+      );
+    }
+  }
+
   const txSourceFiles = Array.from(
     new Set(txRows.map((r) => r.source_file)),
   ).sort();
@@ -100,5 +213,17 @@ export async function loadAccountOptionsView(
     sourceFiles: { transactions: txSourceFiles, positions: posSourceFiles },
     loadedAt: new Date().toISOString(),
     latestSnapshot,
+    markToMarket,
   };
+}
+
+function collectHeldTickers(state: PortfolioState, seed: Seed): string[] {
+  const tickers = new Set<string>();
+  for (const s of seed.initialShares) tickers.add(s.ticker);
+  for (const t of state.transactions) {
+    if ((t.action === "Buy" || t.action === "Sell") && t.ticker) {
+      tickers.add(t.ticker);
+    }
+  }
+  return Array.from(tickers).sort();
 }

--- a/lib/server/account.ts
+++ b/lib/server/account.ts
@@ -1,0 +1,104 @@
+import type Database from "better-sqlite3";
+import { getDb } from "@/lib/db/connection";
+import {
+  type Account,
+  getAccountByUuid,
+} from "@/lib/db/repos/accounts";
+import { listTransactionsByAccount } from "@/lib/db/repos/transactions";
+import {
+  getEarliestSnapshotDate,
+  getLatestSnapshotDate,
+  getSnapshotByDate,
+} from "@/lib/db/repos/positionSnapshots";
+import { getBoolean } from "@/lib/db/repos/settings";
+import {
+  positionsSnapshotFromRows,
+  transactionFromRow,
+} from "@/lib/model/fromDb";
+import { buildPortfolio } from "@/lib/model/portfolio";
+import { chooseSeed } from "@/lib/positions/seed";
+import type { Config, PortfolioState } from "@/lib/model/types";
+import type { PositionsSnapshot } from "@/lib/positions/types";
+
+export type AccountOptionsView =
+  | {
+      kind: "ready";
+      account: Account;
+      state: PortfolioState;
+      sourceFiles: { transactions: string[]; positions: string[] };
+      loadedAt: string;
+      latestSnapshot: PositionsSnapshot | null;
+    }
+  | { kind: "no-data"; account: Account };
+
+export interface LoadAccountOptionsViewOpts {
+  db?: Database.Database;
+}
+
+export async function loadAccountOptionsView(
+  uuid: string,
+  opts: LoadAccountOptionsViewOpts = {},
+): Promise<AccountOptionsView | null> {
+  const db = opts.db ?? getDb();
+
+  const account = getAccountByUuid(db, uuid);
+  if (!account) return null;
+
+  const txRows = listTransactionsByAccount(db, account.id);
+  const transactions = txRows.map(transactionFromRow);
+
+  const earliestSnapDate = getEarliestSnapshotDate(db, account.id);
+  const latestSnapDate = getLatestSnapshotDate(db, account.id);
+  const earliestSnapshot = earliestSnapDate
+    ? positionsSnapshotFromRows(
+        earliestSnapDate,
+        getSnapshotByDate(db, account.id, earliestSnapDate),
+      )
+    : null;
+  const latestSnapshot = latestSnapDate
+    ? positionsSnapshotFromRows(
+        latestSnapDate,
+        getSnapshotByDate(db, account.id, latestSnapDate),
+      )
+    : null;
+
+  if (transactions.length === 0 && earliestSnapshot === null) {
+    return { kind: "no-data", account };
+  }
+
+  const marketDataEnabled = getBoolean(db, "market_data.enabled");
+  const config: Config = {
+    seedDate: account.seedDate ?? earliestSnapshot?.asOf ?? "",
+    seedValue: account.seedValue ?? earliestSnapshot?.totalValue ?? 0,
+    marketData: { enabled: marketDataEnabled },
+    benchmark: account.benchmark,
+  };
+
+  const seed = chooseSeed({
+    transactions,
+    earliestSnapshot,
+    config,
+  });
+
+  const state = buildPortfolio(transactions, config, seed);
+
+  const txSourceFiles = Array.from(
+    new Set(txRows.map((r) => r.source_file)),
+  ).sort();
+  const posSourceFiles = Array.from(
+    new Set(
+      [earliestSnapshot?.sourceFile, latestSnapshot?.sourceFile].filter(
+        (s): s is string => Boolean(s),
+      ),
+    ),
+  ).sort();
+
+  return {
+    kind: "ready",
+    account,
+    state,
+    sourceFiles: { transactions: txSourceFiles, positions: posSourceFiles },
+    loadedAt: new Date().toISOString(),
+    latestSnapshot,
+  };
+}

--- a/lib/server/accountTabs.ts
+++ b/lib/server/accountTabs.ts
@@ -1,0 +1,36 @@
+import { getDb } from "@/lib/db/connection";
+import { getAccountByUuid } from "@/lib/db/repos/accounts";
+import { listTransactionsByAccount } from "@/lib/db/repos/transactions";
+import type { AccountTabFlags } from "@/app/components/AccountTabs";
+
+const OPTION_ACTIONS = new Set([
+  "SELL_TO_OPEN",
+  "BUY_TO_OPEN",
+  "BUY_TO_CLOSE",
+  "SELL_TO_CLOSE",
+  "ASSIGNMENT",
+  "EXERCISE",
+  "EXPIRATION",
+]);
+
+const TRADE_ACTIONS = new Set([
+  "BUY",
+  "SELL",
+  "SELL_TO_OPEN",
+  "BUY_TO_OPEN",
+  "BUY_TO_CLOSE",
+  "SELL_TO_CLOSE",
+]);
+
+export async function getAccountTabFlags(
+  uuid: string,
+): Promise<AccountTabFlags | null> {
+  const db = getDb();
+  const account = getAccountByUuid(db, uuid);
+  if (!account) return null;
+  const txs = listTransactionsByAccount(db, account.id);
+  return {
+    showOptions: txs.some((t) => OPTION_ACTIONS.has(t.action_canonical)),
+    showTrades: txs.some((t) => TRADE_ACTIONS.has(t.action_canonical)),
+  };
+}

--- a/lib/server/home.ts
+++ b/lib/server/home.ts
@@ -16,3 +16,10 @@ export async function loadHome(opts: LoadHomeOpts = {}): Promise<HomeData> {
   const accounts = listAccounts(db);
   return { accounts, loadedAt: new Date().toISOString() };
 }
+
+export async function loadAccounts(
+  opts: LoadHomeOpts = {},
+): Promise<Account[]> {
+  const db = opts.db ?? getDb();
+  return listAccounts(db);
+}

--- a/tests/model/fromDb.test.ts
+++ b/tests/model/fromDb.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import {
+  transactionFromRow,
+  positionsSnapshotFromRows,
+  actionFromCanonical,
+} from "@/lib/model/fromDb";
+import type { TransactionRow } from "@/lib/db/repos/transactions";
+import type { PositionSnapshotRow } from "@/lib/db/repos/positionSnapshots";
+
+const baseTxRow: TransactionRow = {
+  id: 1,
+  account_id: 1,
+  trade_date: "2026-01-05",
+  action_canonical: "BUY",
+  action_raw: "Buy",
+  symbol: "ACME",
+  description: "ACME CORP",
+  quantity: 100,
+  price: 50,
+  fees: 0,
+  amount: -5000,
+  raw: JSON.stringify({
+    Date: "01/05/2026",
+    Action: "Buy",
+    Symbol: "ACME",
+    Description: "ACME CORP",
+    Quantity: "100",
+    Price: "$50.00",
+    "Fees & Comm": "$0.00",
+    Amount: "-$5000.00",
+  }),
+  source_file: "demo.csv",
+  content_hash: "abc",
+};
+
+describe("actionFromCanonical", () => {
+  it("maps BUY to Buy", () => {
+    expect(actionFromCanonical("BUY", "Buy")).toBe("Buy");
+  });
+
+  it("maps SELL_TO_OPEN to SellToOpen", () => {
+    expect(actionFromCanonical("SELL_TO_OPEN", "Sell to Open")).toBe(
+      "SellToOpen",
+    );
+  });
+
+  it("maps DIVIDEND to QualifiedDividend", () => {
+    expect(actionFromCanonical("DIVIDEND", "Qualified Dividend")).toBe(
+      "QualifiedDividend",
+    );
+  });
+
+  it("maps INTEREST to BankInterest", () => {
+    expect(actionFromCanonical("INTEREST", "Bank Interest")).toBe(
+      "BankInterest",
+    );
+  });
+
+  it("maps JOURNAL to Journal", () => {
+    expect(actionFromCanonical("JOURNAL", "Journal")).toBe("Journal");
+  });
+
+  it("falls back to Unknown for UNKNOWN", () => {
+    expect(actionFromCanonical("UNKNOWN", "Some weird action")).toBe(
+      "Unknown",
+    );
+  });
+});
+
+describe("transactionFromRow", () => {
+  it("maps a Buy row to a legacy Transaction with ticker", () => {
+    const tx = transactionFromRow(baseTxRow);
+    expect(tx.tradeDate).toBe("2026-01-05");
+    expect(tx.action).toBe("Buy");
+    expect(tx.ticker).toBe("ACME");
+    expect(tx.option).toBeUndefined();
+    expect(tx.quantity).toBe(100);
+    expect(tx.price).toBe(50);
+    expect(tx.fees).toBe(0);
+    expect(tx.amount).toBe(-5000);
+    expect(tx.rawAction).toBe("Buy");
+  });
+
+  it("maps a Sell-to-Open option row to a Transaction with option leg", () => {
+    const tx = transactionFromRow({
+      ...baseTxRow,
+      action_canonical: "SELL_TO_OPEN",
+      action_raw: "Sell to Open",
+      symbol: "ACME 03/15/2026 100.00 P",
+      description: "PUT ACME CORP $100 EXP 03/15/26",
+      quantity: 1,
+      price: 1.5,
+      amount: 150,
+    });
+    expect(tx.action).toBe("SellToOpen");
+    expect(tx.ticker).toBeUndefined();
+    expect(tx.option).toEqual({
+      ticker: "ACME",
+      expiry: "2026-03-15",
+      strike: 100,
+      type: "Put",
+    });
+  });
+
+  it("preserves raw fields for downstream warning rendering", () => {
+    const tx = transactionFromRow(baseTxRow);
+    expect(tx.raw.Symbol).toBe("ACME");
+    expect(tx.raw.Action).toBe("Buy");
+  });
+
+  it("treats null quantity as 0", () => {
+    const tx = transactionFromRow({ ...baseTxRow, quantity: null });
+    expect(tx.quantity).toBe(0);
+  });
+});
+
+describe("positionsSnapshotFromRows", () => {
+  const snapDate = "2026-04-25";
+  const equityRow: PositionSnapshotRow = {
+    id: 1,
+    account_id: 1,
+    as_of: snapDate,
+    symbol: "ACME",
+    description: "ACME CORP",
+    quantity: 100,
+    price: 50,
+    market_value: 5000,
+    cost_basis: 4500,
+    asset_type: "equity",
+    raw: JSON.stringify({}),
+    source_file: "snap.csv",
+    content_hash: "h",
+  };
+  const optionRow: PositionSnapshotRow = {
+    ...equityRow,
+    id: 2,
+    symbol: "ACME 03/15/2026 100.00 P",
+    description: "PUT ACME CORP",
+    quantity: -1,
+    price: 1.5,
+    market_value: -150,
+    cost_basis: 0,
+    asset_type: "option",
+  };
+  const cashRow: PositionSnapshotRow = {
+    ...equityRow,
+    id: 3,
+    symbol: "Cash & Cash Investments",
+    description: null,
+    quantity: null,
+    price: null,
+    market_value: 1234.56,
+    cost_basis: null,
+    asset_type: "cash",
+  };
+
+  it("groups rows by asset type", () => {
+    const snap = positionsSnapshotFromRows(snapDate, [
+      equityRow,
+      optionRow,
+      cashRow,
+    ]);
+    expect(snap.asOf).toBe(snapDate);
+    expect(snap.cash).toBeCloseTo(1234.56, 2);
+    expect(snap.shares).toHaveLength(1);
+    expect(snap.shares[0].ticker).toBe("ACME");
+    expect(snap.options).toHaveLength(1);
+    expect(snap.options[0].underlying).toBe("ACME");
+    expect(snap.options[0].callPut).toBe("P");
+  });
+
+  it("computes totalValue from row market_values", () => {
+    const snap = positionsSnapshotFromRows(snapDate, [equityRow, cashRow]);
+    expect(snap.totalValue).toBeCloseTo(5000 + 1234.56, 2);
+  });
+});

--- a/tests/model/fromDb.test.ts
+++ b/tests/model/fromDb.test.ts
@@ -35,35 +35,27 @@ const baseTxRow: TransactionRow = {
 
 describe("actionFromCanonical", () => {
   it("maps BUY to Buy", () => {
-    expect(actionFromCanonical("BUY", "Buy")).toBe("Buy");
+    expect(actionFromCanonical("BUY")).toBe("Buy");
   });
 
   it("maps SELL_TO_OPEN to SellToOpen", () => {
-    expect(actionFromCanonical("SELL_TO_OPEN", "Sell to Open")).toBe(
-      "SellToOpen",
-    );
+    expect(actionFromCanonical("SELL_TO_OPEN")).toBe("SellToOpen");
   });
 
   it("maps DIVIDEND to QualifiedDividend", () => {
-    expect(actionFromCanonical("DIVIDEND", "Qualified Dividend")).toBe(
-      "QualifiedDividend",
-    );
+    expect(actionFromCanonical("DIVIDEND")).toBe("QualifiedDividend");
   });
 
   it("maps INTEREST to BankInterest", () => {
-    expect(actionFromCanonical("INTEREST", "Bank Interest")).toBe(
-      "BankInterest",
-    );
+    expect(actionFromCanonical("INTEREST")).toBe("BankInterest");
   });
 
   it("maps JOURNAL to Journal", () => {
-    expect(actionFromCanonical("JOURNAL", "Journal")).toBe("Journal");
+    expect(actionFromCanonical("JOURNAL")).toBe("Journal");
   });
 
   it("falls back to Unknown for UNKNOWN", () => {
-    expect(actionFromCanonical("UNKNOWN", "Some weird action")).toBe(
-      "Unknown",
-    );
+    expect(actionFromCanonical("UNKNOWN")).toBe("Unknown");
   });
 });
 

--- a/tests/schwab/optionSymbol.test.ts
+++ b/tests/schwab/optionSymbol.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { parseOptionSymbol } from "@/lib/schwab/optionSymbol";
+
+describe("parseOptionSymbol", () => {
+  it("parses a Schwab call-option symbol", () => {
+    expect(parseOptionSymbol("ACME 03/15/2026 100.00 C")).toEqual({
+      ticker: "ACME",
+      expiry: "2026-03-15",
+      strike: 100,
+      type: "Call",
+    });
+  });
+
+  it("parses a Schwab put-option symbol", () => {
+    expect(parseOptionSymbol("ACME 12/19/2025 47.50 P")).toEqual({
+      ticker: "ACME",
+      expiry: "2025-12-19",
+      strike: 47.5,
+      type: "Put",
+    });
+  });
+
+  it("returns null for an equity ticker", () => {
+    expect(parseOptionSymbol("ACME")).toBeNull();
+  });
+
+  it("returns null for null", () => {
+    expect(parseOptionSymbol(null)).toBeNull();
+  });
+
+  it("returns null for an unrecognized format", () => {
+    expect(parseOptionSymbol("ACME WEEKLY 100C")).toBeNull();
+  });
+});

--- a/tests/server/account.test.ts
+++ b/tests/server/account.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import path from "node:path";
+import { runMigrations } from "@/lib/db/migrate";
+import { upsertAccount, setSeed } from "@/lib/db/repos/accounts";
+import { insertTransaction } from "@/lib/db/repos/transactions";
+import { insertSnapshot } from "@/lib/db/repos/positionSnapshots";
+import { setBoolean } from "@/lib/db/repos/settings";
+import { loadAccountOptionsView } from "@/lib/server/account";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  runMigrations(db, path.join(process.cwd(), "db", "migrations"));
+  return db;
+}
+
+describe("loadAccountOptionsView", () => {
+  it("returns null when uuid is unknown", async () => {
+    const db = makeDb();
+    const result = await loadAccountOptionsView(
+      "00000000-0000-0000-0000-000000000000",
+      { db },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns no-data when account exists but has no transactions or snapshots", async () => {
+    const db = makeDb();
+    const account = upsertAccount(db, { externalId: "100", label: "Demo" });
+    setSeed(db, "100", "2026-01-15", 12345);
+    const result = await loadAccountOptionsView(account.uuid, { db });
+    expect(result?.kind).toBe("no-data");
+  });
+
+  it("builds a PortfolioState when transactions exist", async () => {
+    const db = makeDb();
+    setBoolean(db, "market_data.enabled", false);
+    const account = upsertAccount(db, { externalId: "100", label: "Demo" });
+    setSeed(db, "100", "2026-01-01", 10000);
+
+    insertTransaction(
+      db,
+      account.id,
+      {
+        tradeDate: "2026-01-05",
+        actionCanonical: "BUY",
+        actionRaw: "Buy",
+        symbol: "ACME",
+        description: "ACME CORP",
+        quantity: 100,
+        price: 50,
+        fees: 0,
+        amount: -5000,
+        raw: { Action: "Buy" },
+      },
+      "demo.csv",
+    );
+
+    insertSnapshot(
+      db,
+      account.id,
+      {
+        asOf: "2026-04-25",
+        symbol: "ACME",
+        description: "ACME CORP",
+        quantity: 100,
+        price: 60,
+        marketValue: 6000,
+        costBasis: 5000,
+        assetType: "equity",
+        raw: {},
+      },
+      "snap.csv",
+    );
+
+    const result = await loadAccountOptionsView(account.uuid, { db });
+    expect(result?.kind).toBe("ready");
+    if (result?.kind !== "ready") return;
+    expect(result.account.uuid).toBe(account.uuid);
+    expect(result.state.config.seedValue).toBe(10000);
+    expect(result.state.transactions).toHaveLength(1);
+    expect(result.state.cashLedger.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to earliest snapshot for seed when no override is set", async () => {
+    const db = makeDb();
+    setBoolean(db, "market_data.enabled", false);
+    const account = upsertAccount(db, { externalId: "200", label: "Demo2" });
+    insertSnapshot(
+      db,
+      account.id,
+      {
+        asOf: "2026-04-01",
+        symbol: "ACME",
+        description: "ACME CORP",
+        quantity: 100,
+        price: 40,
+        marketValue: 4000,
+        costBasis: 4000,
+        assetType: "equity",
+        raw: {},
+      },
+      "snap.csv",
+    );
+
+    const result = await loadAccountOptionsView(account.uuid, { db });
+    expect(result?.kind).toBe("ready");
+    if (result?.kind !== "ready") return;
+    expect(result.state.config.seedDate).toBe("2026-04-01");
+  });
+});

--- a/tests/server/account.test.ts
+++ b/tests/server/account.test.ts
@@ -82,6 +82,36 @@ describe("loadAccountOptionsView", () => {
     expect(result.state.cashLedger.length).toBeGreaterThan(0);
   });
 
+  it("includes a markToMarket field that is null when no held positions", async () => {
+    const db = makeDb();
+    setBoolean(db, "market_data.enabled", true);
+    const account = upsertAccount(db, { externalId: "300", label: "Demo3" });
+    setSeed(db, "300", "2026-01-01", 10000);
+    insertSnapshot(
+      db,
+      account.id,
+      {
+        asOf: "2026-01-01",
+        symbol: "Cash & Cash Investments",
+        description: null,
+        quantity: null,
+        price: null,
+        marketValue: 10000,
+        costBasis: null,
+        assetType: "cash",
+        raw: {},
+      },
+      "snap.csv",
+    );
+    const result = await loadAccountOptionsView(account.uuid, {
+      db,
+      includeMarketData: false,
+    });
+    expect(result?.kind).toBe("ready");
+    if (result?.kind !== "ready") return;
+    expect(result.markToMarket).toBeNull();
+  });
+
   it("falls back to earliest snapshot for seed when no override is set", async () => {
     const db = makeDb();
     setBoolean(db, "market_data.enabled", false);


### PR DESCRIPTION
## Summary

Implements issue #3. Restores the legacy options/wheel dashboard at `/accounts/[uuid]/options`, sourced from the SQLite DB shipped in #1, and makes the global nav account-aware.

## What changed

- `lib/schwab/optionSymbol.ts` — parses Schwab option-symbol strings (e.g., `"ACME 03/15/2026 100.00 P"`) into the legacy `OptionLeg` shape.
- `lib/model/fromDb.ts` — thin adapter from DB rows to legacy `Transaction` / `PositionsSnapshot` shapes (action enum mapping, option-leg parsing, asset-type grouping). Only place that knows about the canonical-vs-legacy difference.
- `lib/server/account.ts` — `loadAccountOptionsView(uuid)` orchestrates account lookup, row mapping, `chooseSeed`, `buildPortfolio`, market-data fetching, mark-to-market. Returns a discriminated union (`ready` / `no-data` / `null` for unknown UUID).
- `lib/server/accountTabs.ts` — `getAccountTabFlags` scans transactions to decide which per-account tabs are visible.
- `app/accounts/[uuid]/layout.tsx` — guard layout, 404s on unknown UUIDs.
- `app/accounts/[uuid]/options/page.tsx` — wheel dashboard at the new URL; renders the same 12 cards as before, plus the per-account sub-nav at the top.
- `app/components/AccountTabs.tsx` — Overview / Options / Trades / Transactions tab strip; Options/Trades hidden when no matching transactions exist.
- `app/components/AccountPicker.tsx` — client-side `<select>` for switching accounts.
- `app/components/AppNav.tsx` + `app/layout.tsx` — root layout fetches accounts and renders them in the picker.
- `lib/server/home.ts` — exports `loadAccounts()` for use by the root layout.

## Deviation from issue body

The issue body says `/` should redirect to `/accounts/<first-account-uuid>/options`. After #1 we ship a useful accounts-list landing at `/`. This PR keeps the accounts list — works for any number of accounts, no awkward auto-pick — and the rows already link straight to `/accounts/{uuid}/options`. Easy to revisit if redirect behavior is preferred.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (1 pre-existing unrelated warning in `tests/market/quotes.test.ts`)
- [x] `npm test` passes — 244 tests across 38 files
- [x] Manual smoke: ingest fixtures → `/` shows accounts list with picker → click Options on the row → `/accounts/{uuid}/options` renders the wheel dashboard with Overview / Options / Trades / Transactions sub-nav (Options bold), all 12 cards visible
- [x] Manual smoke: `/accounts/00000000-0000-0000-0000-000000000000/options` → 404
- [ ] Reviewer: repeat the manual smoke test above

*Co-authored by Claude*