### PR TITLE
Stop polluting seed config with snapshot fallback when chooseSeed rejects it

### DIFF
--- a/lib/server/account.ts
+++ b/lib/server/account.ts
@@ -77,9 +77,9 @@ export async function loadAccountOptionsView(
   }
 
   const marketDataEnabled = getBoolean(db, "market_data.enabled");
-  const config: Config = {
-    seedDate: account.seedDate ?? earliestSnapshot?.asOf ?? "",
-    seedValue: account.seedValue ?? earliestSnapshot?.totalValue ?? 0,
+  const bootstrap: Config = {
+    seedDate: account.seedDate ?? "",
+    seedValue: account.seedValue ?? 0,
     marketData: { enabled: marketDataEnabled },
     benchmark: account.benchmark,
   };
@@ -87,8 +87,17 @@ export async function loadAccountOptionsView(
   const seed = chooseSeed({
     transactions,
     earliestSnapshot,
-    config,
+    config: bootstrap,
   });
+
+  const config: Config =
+    earliestSnapshot !== null && seed.asOf === earliestSnapshot.asOf.slice(0, 10)
+      ? {
+          ...bootstrap,
+          seedDate: earliestSnapshot.asOf.slice(0, 10),
+          seedValue: account.seedValue ?? earliestSnapshot.totalValue,
+        }
+      : bootstrap;
 
   const state = buildPortfolio(transactions, config, seed);
 

--- a/lib/server/accountOverview.ts
+++ b/lib/server/accountOverview.ts
@@ -120,14 +120,24 @@ export async function loadAccountOverviewView(
   }
 
   const marketDataEnabled = getBoolean(db, "market_data.enabled");
-  const config: Config = {
-    seedDate: account.seedDate ?? earliestSnapshot?.asOf ?? "",
-    seedValue: account.seedValue ?? earliestSnapshot?.totalValue ?? 0,
+  const bootstrap: Config = {
+    seedDate: account.seedDate ?? "",
+    seedValue: account.seedValue ?? 0,
     marketData: { enabled: marketDataEnabled },
     benchmark: account.benchmark,
   };
 
-  const seed = chooseSeed({ transactions, earliestSnapshot, config });
+  const seed = chooseSeed({ transactions, earliestSnapshot, config: bootstrap });
+
+  const config: Config =
+    earliestSnapshot !== null && seed.asOf === earliestSnapshot.asOf.slice(0, 10)
+      ? {
+          ...bootstrap,
+          seedDate: earliestSnapshot.asOf.slice(0, 10),
+          seedValue: account.seedValue ?? earliestSnapshot.totalValue,
+        }
+      : bootstrap;
+
   const state = buildPortfolio(transactions, config, seed);
 
   const today = opts.today ?? yesterdayInET();

--- a/tests/server/account.test.ts
+++ b/tests/server/account.test.ts
@@ -112,6 +112,57 @@ describe("loadAccountOptionsView", () => {
     expect(result.markToMarket).toBeNull();
   });
 
+  it("keeps all transactions when snapshot post-dates them and no override is set", async () => {
+    // Regression for issue #23: previously the loader fell back to the snapshot
+    // date as the config seed, which then filtered out every transaction
+    // before that date — even though chooseSeed correctly rejected the
+    // snapshot as a seed.
+    const db = makeDb();
+    setBoolean(db, "market_data.enabled", false);
+    const account = upsertAccount(db, { externalId: "999", label: "DemoBug" });
+    for (const date of ["2026-01-05", "2026-02-10", "2026-03-15", "2026-04-20"]) {
+      insertTransaction(
+        db,
+        account.id,
+        {
+          tradeDate: date,
+          actionCanonical: "BUY",
+          actionRaw: "Buy",
+          symbol: "ACME",
+          description: "ACME CORP",
+          quantity: 1,
+          price: 50,
+          fees: 0,
+          amount: -50,
+          raw: { Action: "Buy" },
+        },
+        "demo.csv",
+      );
+    }
+    insertSnapshot(
+      db,
+      account.id,
+      {
+        asOf: "2026-04-28",
+        symbol: "ACME",
+        description: "ACME CORP",
+        quantity: 4,
+        price: 60,
+        marketValue: 240,
+        costBasis: 200,
+        assetType: "equity",
+        raw: {},
+      },
+      "snap.csv",
+    );
+
+    const result = await loadAccountOptionsView(account.uuid, { db });
+    if (result?.kind !== "ready") throw new Error("expected ready");
+    expect(result.state.transactions).toHaveLength(4);
+    expect(result.state.config.seedDate).toBe("");
+    expect(result.state.config.seedValue).toBe(0);
+  });
+
   it("falls back to earliest snapshot for seed when no override is set", async () => {
     const db = makeDb();
     setBoolean(db, "market_data.enabled", false);

--- a/tests/server/accountOverview.test.ts
+++ b/tests/server/accountOverview.test.ts
@@ -118,6 +118,59 @@ describe("loadAccountOverviewView", () => {
     ).toBeTruthy();
   });
 
+  it("keeps all transactions when snapshot post-dates them and no override is set", async () => {
+    // Regression for issue #23.
+    const db = makeDb();
+    setBoolean(db, "market_data.enabled", false);
+    const account = upsertAccount(db, { externalId: "999", label: "DemoBug" });
+    for (const date of ["2026-01-05", "2026-02-10", "2026-03-15", "2026-04-20"]) {
+      insertTransaction(
+        db,
+        account.id,
+        {
+          tradeDate: date,
+          actionCanonical: "BUY",
+          actionRaw: "Buy",
+          symbol: "ACME",
+          description: "ACME CORP",
+          quantity: 1,
+          price: 50,
+          fees: 0,
+          amount: -50,
+          raw: { Action: "Buy" },
+        },
+        "demo.csv",
+      );
+    }
+    insertSnapshot(
+      db,
+      account.id,
+      {
+        asOf: "2026-04-28",
+        symbol: "ACME",
+        description: "ACME CORP",
+        quantity: 4,
+        price: 60,
+        marketValue: 240,
+        costBasis: 200,
+        assetType: "equity",
+        raw: {},
+      },
+      "snap.csv",
+    );
+
+    const result = await loadAccountOverviewView(account.uuid, {
+      db,
+      period: "YTD",
+      today: "2026-04-29",
+      includeMarketData: false,
+    });
+    if (result?.kind !== "ready") throw new Error("expected ready");
+    expect(result.transactions).toHaveLength(4);
+    expect(result.nav.computation.seedDate).toBe("");
+    expect(result.nav.computation.seedValue).toBe(0);
+  });
+
   it("clamps period start to seed when period predates seed", async () => {
     const db = makeDb();
     setBoolean(db, "market_data.enabled", false);


### PR DESCRIPTION
## Summary
- Fixes #23. The Overview and Options loaders fell back to `earliestSnapshot.asOf` as `config.seedDate` when no account seed was configured. `chooseSeed` then correctly recognized the snapshot couldn't serve as the seed (transactions exist before it) and returned a `configSeed` — but with the already-polluted snapshot date. `buildPortfolio`'s `t.tradeDate >= seed.asOf` filter dropped every transaction before the snapshot, leaving exactly one row visible on both pages.
- The fix passes the bare account-configured seed (or empty/zero) to `chooseSeed`, then derives the canonical config from whichever seed `chooseSeed` actually picked. When `chooseSeed` returns the snapshot-based seed, mirror its `asOf` and use the snapshot's `totalValue` as the starting NAV. Otherwise leave the config empty so all transactions pass the filter.
- Adds regression tests for the bug case to both loader test files.

## Layer A vs Layer B
This is the **Layer A** filtering fix from #23. **Layer B** — honest period returns when there's no configured seed and no usable snapshot — is still open: without a known starting NAV, period returns derived from the empty seed are mathematically meaningless. A separate follow-up should either suppress period-return display in that state or surface a clearer banner pointing the user at \`npm run account:configure\`.

## Test plan
- [x] \`npm test\` — 259/259 pass
- [x] \`npm run lint\` — clean (1 pre-existing unrelated warning)
- [x] \`npm run typecheck\` — clean
- [x] New regression test in \`tests/server/account.test.ts\` and \`tests/server/accountOverview.test.ts\` exercises the bug scenario (4 transactions before a single later snapshot, no configured seed) and asserts all 4 transactions survive

*Co-authored by Claude*