### PR TITLE
Suppress period returns and warn when account has no honest starting NAV

### DIFF
--- a/app/components/AttentionBanner.tsx
+++ b/app/components/AttentionBanner.tsx
@@ -12,6 +12,8 @@ function describe(w: Warning): string {
       return `Assignment on ${w.date} (${w.contractKey}) has no matching Buy/Sell share row.`;
     case "MissingHistoricalPrices":
       return `Historical closes unavailable for ${w.ticker} — Portfolio Value excludes this ticker's contribution on missing dates. (${w.reason})`;
+    case "MissingSeed":
+      return `No starting NAV configured — period and "since seed" returns are unavailable. Run \`npm run account:configure\` to set a seed date and value.`;
   }
 }
 

--- a/app/components/OverviewSummaryStrip.tsx
+++ b/app/components/OverviewSummaryStrip.tsx
@@ -12,6 +12,7 @@ export function OverviewSummaryStrip({ nav, cash, holdingsCount }: Props) {
   const positive = changeAmount >= 0;
   const periodLabel = computation.period;
   const sign = positive ? "+" : "−";
+  const hasHonestSeed = computation.seedValue > 0 && computation.seedDate !== "";
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-4">
@@ -22,10 +23,14 @@ export function OverviewSummaryStrip({ nav, cash, holdingsCount }: Props) {
       />
       <Card
         label={`Return · ${periodLabel}`}
-        value={`${positive ? "+" : ""}${(changePct * 100).toFixed(2)}%`}
-        valueClass={positive ? "text-emerald-600" : "text-red-600"}
-        delta={`${sign}${formatCurrency(Math.abs(changeAmount))} since ${computation.effectiveStart}`}
-        deltaClass={positive ? "text-emerald-600" : "text-red-600"}
+        value={hasHonestSeed ? `${positive ? "+" : ""}${(changePct * 100).toFixed(2)}%` : "—"}
+        valueClass={hasHonestSeed ? (positive ? "text-emerald-600" : "text-red-600") : "text-gray-400 dark:text-gray-500"}
+        delta={
+          hasHonestSeed
+            ? `${sign}${formatCurrency(Math.abs(changeAmount))} since ${computation.effectiveStart}`
+            : "no seed configured"
+        }
+        deltaClass={hasHonestSeed ? (positive ? "text-emerald-600" : "text-red-600") : undefined}
       />
       <Card
         label="Cash"

--- a/app/components/ReturnMetricsCard.tsx
+++ b/app/components/ReturnMetricsCard.tsx
@@ -9,6 +9,8 @@ function formatPct(n: number): string {
 
 export function ReturnMetricsCard({ state }: Props) {
   const r = computeReturnMetrics(state.navSeries, state.externalFlows, state.config);
+  const hasHonestSeed = state.config.seedValue > 0 && state.config.seedDate !== "";
+  const muted = "text-gray-400 dark:text-gray-500";
   const color = (n: number) =>
     n >= 0 ? "text-emerald-700 dark:text-emerald-400" : "text-red-700 dark:text-red-400";
 
@@ -22,23 +24,33 @@ export function ReturnMetricsCard({ state }: Props) {
         subtracted from performance.
       </p>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <Tile label="Total return" value={formatPct(r.totalReturnPct)} valueClass={color(r.totalReturnPct)} sub={`${r.daysSinceSeed} days`} />
-        <Tile label="Annualized" value={formatPct(r.annualizedPct)} valueClass={color(r.annualizedPct)} sub="(365-day basis)" />
+        <Tile
+          label="Total return"
+          value={hasHonestSeed ? formatPct(r.totalReturnPct) : "—"}
+          valueClass={hasHonestSeed ? color(r.totalReturnPct) : muted}
+          sub={hasHonestSeed ? `${r.daysSinceSeed} days` : "no seed configured"}
+        />
+        <Tile
+          label="Annualized"
+          value={hasHonestSeed ? formatPct(r.annualizedPct) : "—"}
+          valueClass={hasHonestSeed ? color(r.annualizedPct) : muted}
+          sub={hasHonestSeed ? "(365-day basis)" : "no seed configured"}
+        />
         <Tile
           label="Best month"
-          value={r.bestMonth ? formatPct(r.bestMonth.returnPct) : "—"}
-          valueClass={r.bestMonth ? color(r.bestMonth.returnPct) : ""}
-          sub={r.bestMonth?.month ?? ""}
+          value={hasHonestSeed && r.bestMonth ? formatPct(r.bestMonth.returnPct) : "—"}
+          valueClass={hasHonestSeed && r.bestMonth ? color(r.bestMonth.returnPct) : muted}
+          sub={hasHonestSeed ? (r.bestMonth?.month ?? "") : ""}
         />
         <Tile
           label="Worst month"
-          value={r.worstMonth ? formatPct(r.worstMonth.returnPct) : "—"}
-          valueClass={r.worstMonth ? color(r.worstMonth.returnPct) : ""}
-          sub={r.worstMonth?.month ?? ""}
+          value={hasHonestSeed && r.worstMonth ? formatPct(r.worstMonth.returnPct) : "—"}
+          valueClass={hasHonestSeed && r.worstMonth ? color(r.worstMonth.returnPct) : muted}
+          sub={hasHonestSeed ? (r.worstMonth?.month ?? "") : ""}
         />
       </div>
 
-      {r.monthly.length > 0 && (
+      {hasHonestSeed && r.monthly.length > 0 && (
         <div className="mt-4">
           <div className="text-[11px] uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1">
             Monthly

--- a/app/components/SummaryStrip.tsx
+++ b/app/components/SummaryStrip.tsx
@@ -10,8 +10,9 @@ export function SummaryStrip({ state, markToMarket }: Props) {
     (a, e) => a + e.signedAmount,
     0,
   );
+  const hasHonestSeed = state.config.seedValue > 0 && state.config.seedDate !== "";
   const gain = nav - state.config.seedValue - cumulativeExternal;
-  const returnPct = gain / state.config.seedValue;
+  const returnPct = hasHonestSeed ? gain / state.config.seedValue : 0;
   const finalCash =
     state.cashLedger.at(-1)?.balance ?? state.config.seedValue;
   const sharesAtCost = state.openSharePositions.reduce(
@@ -27,14 +28,22 @@ export function SummaryStrip({ state, markToMarket }: Props) {
         <Card
           label="Options Income NAV"
           value={formatCurrency(nav)}
-          delta={`${gain >= 0 ? "+" : "−"}${formatCurrency(Math.abs(gain))} since seed`}
-          deltaClass={deltaColor}
+          delta={
+            hasHonestSeed
+              ? `${gain >= 0 ? "+" : "−"}${formatCurrency(Math.abs(gain))} since seed`
+              : `as of ${state.navSeries.at(-1)?.date ?? "—"}`
+          }
+          deltaClass={hasHonestSeed ? deltaColor : undefined}
         />
         <Card
           label="Return since seed"
-          value={`${(returnPct * 100).toFixed(2)}%`}
-          valueClass={pctColor}
-          delta={`external flows ${formatCurrency(cumulativeExternal)}`}
+          value={hasHonestSeed ? `${(returnPct * 100).toFixed(2)}%` : "—"}
+          valueClass={hasHonestSeed ? pctColor : "text-gray-400 dark:text-gray-500"}
+          delta={
+            hasHonestSeed
+              ? `external flows ${formatCurrency(cumulativeExternal)}`
+              : "no seed configured"
+          }
         />
         <Card
           label="Cash"

--- a/lib/model/types.ts
+++ b/lib/model/types.ts
@@ -31,7 +31,8 @@ export type Warning =
   | { kind: "CashDrift"; expected: number; actual: number }
   | { kind: "NegativeShareEndOfDay"; ticker: string; date: string; shares: number }
   | { kind: "UnpairedAssignment"; date: string; contractKey: string }
-  | { kind: "MissingHistoricalPrices"; ticker: string; reason: string };
+  | { kind: "MissingHistoricalPrices"; ticker: string; reason: string }
+  | { kind: "MissingSeed" };
 
 export type PortfolioState = {
   config: Config;

--- a/lib/server/account.ts
+++ b/lib/server/account.ts
@@ -101,6 +101,10 @@ export async function loadAccountOptionsView(
 
   const state = buildPortfolio(transactions, config, seed);
 
+  if (config.seedValue === 0 && config.seedDate === "") {
+    state.warnings.push({ kind: "MissingSeed" });
+  }
+
   let markToMarket: MarkToMarket | null = null;
   const includeMarket = (opts.includeMarketData ?? true) && marketDataEnabled;
 

--- a/lib/server/accountOverview.ts
+++ b/lib/server/accountOverview.ts
@@ -140,6 +140,10 @@ export async function loadAccountOverviewView(
 
   const state = buildPortfolio(transactions, config, seed);
 
+  if (config.seedValue === 0 && config.seedDate === "") {
+    state.warnings.push({ kind: "MissingSeed" });
+  }
+
   const today = opts.today ?? yesterdayInET();
   const period = resolvePeriod(opts.period, today, seed.asOf);
 

--- a/tests/server/account.test.ts
+++ b/tests/server/account.test.ts
@@ -161,6 +161,7 @@ describe("loadAccountOptionsView", () => {
     expect(result.state.transactions).toHaveLength(4);
     expect(result.state.config.seedDate).toBe("");
     expect(result.state.config.seedValue).toBe(0);
+    expect(result.state.warnings.some((w) => w.kind === "MissingSeed")).toBe(true);
   });
 
   it("falls back to earliest snapshot for seed when no override is set", async () => {

--- a/tests/server/accountOverview.test.ts
+++ b/tests/server/accountOverview.test.ts
@@ -169,6 +169,7 @@ describe("loadAccountOverviewView", () => {
     expect(result.transactions).toHaveLength(4);
     expect(result.nav.computation.seedDate).toBe("");
     expect(result.nav.computation.seedValue).toBe(0);
+    expect(result.warnings.some((w) => w.kind === "MissingSeed")).toBe(true);
   });
 
   it("clamps period start to seed when period predates seed", async () => {


### PR DESCRIPTION
## Summary
- Closes #25 (Layer B follow-up to #23). Without a configured seed (and no usable snapshot to seed from), the loaders left \`config.seedDate=""\` and \`seedValue=0\`. The Overview's Return card divided 0/0 and showed +0.00% beside a non-zero dollar delta; the Options \`SummaryStrip\` and \`ReturnMetricsCard\` divided by zero and rendered \`Infinity%\`.
- Adds a \`MissingSeed\` warning kind. Both loaders push it when \`config.seedDate === "" && config.seedValue === 0\`.
- \`AttentionBanner\` describes it with copy pointing the user at \`npm run account:configure\`.
- \`OverviewSummaryStrip\`, \`SummaryStrip\`, and \`ReturnMetricsCard\` render \`—\` with a muted "no seed configured" subtitle when no honest seed; \`ReturnMetricsCard\` also hides the monthly breakdown in that state.
- Loader regression tests assert the warning is pushed in the bug scenario.

## Verified locally
- \`npm test\` — 259/259 pass
- \`npm run lint\` — clean (1 pre-existing unrelated warning)
- \`npm run typecheck\` — clean
- Curl-checked the live page: banner copy renders, \`Infinity%\` no longer present on Options, \`no seed configured\` subtitle visible on both pages

*Co-authored by Claude*