### PR TITLE
Use live snapshot mark-to-market for Overview NAV

### DIFF
--- a/lib/server/accountOverview.ts
+++ b/lib/server/accountOverview.ts
@@ -153,7 +153,11 @@ export async function loadAccountOverviewView(
     await enrichWithMarketData(state, seed, today);
   }
 
-  const nav = buildNavStrip(state, latestSnapshot?.totalValue ?? null, period);
+  const liveNav =
+    latestSnapshotRows.length > 0
+      ? computeLiveNavFromSnapshot(latestSnapshotRows)
+      : null;
+  const nav = buildNavStrip(state, liveNav, period);
 
   const quoteMap: Record<string, Quote | null> = {};
   if (includeMarket) {
@@ -250,7 +254,7 @@ async function enrichWithMarketData(
 
 function buildNavStrip(
   state: PortfolioState,
-  latestSnapshotTotalValue: number | null,
+  liveNav: number | null,
   period: ResolvedPeriod,
 ): NavStripData {
   const series =
@@ -258,8 +262,11 @@ function buildNavStrip(
       ? state.portfolioValueSeries
       : state.navSeries;
 
+  // Mark-to-market live NAV from the latest snapshot wins when present —
+  // it reflects what the account is actually worth today (stocks + cash).
+  // Options market value is intentionally excluded for now.
   const current =
-    series.at(-1)?.nav ?? latestSnapshotTotalValue ?? state.config.seedValue;
+    liveNav ?? series.at(-1)?.nav ?? state.config.seedValue;
 
   const startPoint = closestOnOrBefore(series, period.start);
   const start = startPoint?.nav ?? state.config.seedValue;
@@ -315,6 +322,16 @@ function isCashRow(row: PositionSnapshotRow): boolean {
 function isOptionLike(assetType: string | null): boolean {
   const lowered = (assetType ?? "").toLowerCase();
   return lowered === "option" || lowered === "options";
+}
+
+function computeLiveNavFromSnapshot(rows: PositionSnapshotRow[]): number {
+  let total = 0;
+  for (const r of rows) {
+    if (isCashRow(r) || isEquityLike(r.asset_type)) {
+      total += r.market_value ?? 0;
+    }
+  }
+  return total;
 }
 
 function buildHoldings(

--- a/tests/server/accountOverview.test.ts
+++ b/tests/server/accountOverview.test.ts
@@ -102,7 +102,9 @@ describe("loadAccountOverviewView", () => {
     if (result?.kind !== "ready") return;
 
     expect(result.account.uuid).toBe(account.uuid);
-    expect(result.nav.current).toBeGreaterThan(0);
+    // nav.current should equal mark-to-market (equity + cash) from the latest
+    // snapshot, not the cost-basis ledger value.
+    expect(result.nav.current).toBe(11000);
     expect(result.holdings.find((h) => h.symbol === "ACME")?.value).toBe(6000);
     expect(result.transactions).toHaveLength(1);
     expect(result.allocation.bar.length).toBeGreaterThan(0);
@@ -170,6 +172,72 @@ describe("loadAccountOverviewView", () => {
     expect(result.nav.computation.seedDate).toBe("");
     expect(result.nav.computation.seedValue).toBe(0);
     expect(result.warnings.some((w) => w.kind === "MissingSeed")).toBe(true);
+  });
+
+  it("uses live snapshot mark-to-market for current NAV, ignoring options", async () => {
+    const db = makeDb();
+    setBoolean(db, "market_data.enabled", false);
+    const account = upsertAccount(db, { externalId: "300", label: "Demo3" });
+    setSeed(db, "300", "2026-01-01", 10000);
+    insertSnapshot(
+      db,
+      account.id,
+      {
+        asOf: "2026-04-25",
+        symbol: "ACME",
+        description: "ACME",
+        quantity: 100,
+        price: 75,
+        marketValue: 7500,
+        costBasis: 5000,
+        assetType: "equity",
+        raw: {},
+      },
+      "snap.csv",
+    );
+    insertSnapshot(
+      db,
+      account.id,
+      {
+        asOf: "2026-04-25",
+        symbol: "Cash & Cash Investments",
+        description: null,
+        quantity: null,
+        price: null,
+        marketValue: 2000,
+        costBasis: null,
+        assetType: "cash",
+        raw: {},
+      },
+      "snap.csv",
+    );
+    // An option row that should be excluded from the live NAV (for now).
+    insertSnapshot(
+      db,
+      account.id,
+      {
+        asOf: "2026-04-25",
+        symbol: "ACME 2026-05-01 50P",
+        description: null,
+        quantity: -1,
+        price: 1.5,
+        marketValue: -150,
+        costBasis: null,
+        assetType: "option",
+        raw: {},
+      },
+      "snap.csv",
+    );
+
+    const result = await loadAccountOverviewView(account.uuid, {
+      db,
+      period: "YTD",
+      today: "2026-04-29",
+      includeMarketData: false,
+    });
+    if (result?.kind !== "ready") throw new Error("expected ready");
+    // 7500 (equity) + 2000 (cash). Option row's -150 is excluded.
+    expect(result.nav.current).toBe(9500);
   });
 
   it("clamps period start to seed when period predates seed", async () => {


### PR DESCRIPTION
## Summary
- The Overview "NAV" stat read from \`state.navSeries.at(-1)\`, which is a cost-basis ledger (cash + shares-at-cost). For accounts with snapshots that's wrong — the snapshot already carries the actual mark-to-market value of every held position.
- Adds \`computeLiveNavFromSnapshot\`: sums equity + cash \`market_value\` rows from the latest snapshot, **skipping option rows for now**. Loader passes this as \`liveNav\` to \`buildNavStrip\`, which uses it as \`current\` when present and falls back to the cost-basis series otherwise (no snapshot → unchanged behavior).
- Side effects (positive): the Cash card's "% of NAV" and the Holdings table's "% of acct" become meaningful — both were dividing snapshot dollar values by the cost-basis NAV, producing things like "SOFI 100.7% of acct".

## What's intentionally still cost-basis
- The period-start point (used for 1M / 3M / YTD / 1Y returns mid-history) still reads from \`state.navSeries\`. Without historical mark-to-market data (\`market_data.enabled = true\`), there's no honest source for "what was the account worth on YYYY-MM-DD." For the "All" period and any period that clamps to seed, start = seed value, which is mark-to-market when the seed came from the snapshot or from a user-configured starting NAV.
- Option positions are excluded from the live NAV. Treating short options' contingent-liability (negative \`market_value\`) is a deliberate future call.

## Verified locally
- \`npm test\` — 260/260 pass (one new regression test pinning live-NAV behavior with an option row mixed in)
- \`npm run lint\` / \`npm run typecheck\` — clean
- Local Stonks account: Overview NAV jumped from \$3,669 (cost-basis) to \$25,624 (live snapshot equity + cash); Cash card "% of NAV" dropped from 500.6% to 71.7%; Holdings "% of acct" went from SOFI 100.7% to SOFI 14.4%.

*Co-authored by Claude*