### PR TITLE
Remove market_data.enabled user-facing gate

### DIFF
--- a/lib/server/account.ts
+++ b/lib/server/account.ts
@@ -10,7 +10,6 @@ import {
   getLatestSnapshotDate,
   getSnapshotByDate,
 } from "@/lib/db/repos/positionSnapshots";
-import { getBoolean } from "@/lib/db/repos/settings";
 import { fetchQuotes, type Quote } from "@/lib/market/quotes";
 import { loadHistoricalCloses } from "@/lib/market/historical";
 import {
@@ -76,11 +75,10 @@ export async function loadAccountOptionsView(
     return { kind: "no-data", account };
   }
 
-  const marketDataEnabled = getBoolean(db, "market_data.enabled");
   const bootstrap: Config = {
     seedDate: account.seedDate ?? "",
     seedValue: account.seedValue ?? 0,
-    marketData: { enabled: marketDataEnabled },
+    marketData: { enabled: true },
     benchmark: account.benchmark,
   };
 
@@ -106,7 +104,7 @@ export async function loadAccountOptionsView(
   }
 
   let markToMarket: MarkToMarket | null = null;
-  const includeMarket = (opts.includeMarketData ?? true) && marketDataEnabled;
+  const includeMarket = opts.includeMarketData ?? true;
 
   if (includeMarket) {
     const heldTickers = collectHeldTickers(state, seed);

--- a/lib/server/accountOverview.ts
+++ b/lib/server/accountOverview.ts
@@ -11,7 +11,6 @@ import {
   getSnapshotByDate,
   type PositionSnapshotRow,
 } from "@/lib/db/repos/positionSnapshots";
-import { getBoolean } from "@/lib/db/repos/settings";
 import { fetchQuotes, type Quote } from "@/lib/market/quotes";
 import { loadHistoricalCloses } from "@/lib/market/historical";
 import {
@@ -111,19 +110,15 @@ export async function loadAccountOverviewView(
   const latestSnapshotRows = latestSnapDate
     ? getSnapshotByDate(db, account.id, latestSnapDate)
     : [];
-  const latestSnapshot = latestSnapDate
-    ? positionsSnapshotFromRows(latestSnapDate, latestSnapshotRows)
-    : null;
 
   if (transactions.length === 0 && earliestSnapshot === null) {
     return { kind: "no-data", account };
   }
 
-  const marketDataEnabled = getBoolean(db, "market_data.enabled");
   const bootstrap: Config = {
     seedDate: account.seedDate ?? "",
     seedValue: account.seedValue ?? 0,
-    marketData: { enabled: marketDataEnabled },
+    marketData: { enabled: true },
     benchmark: account.benchmark,
   };
 
@@ -147,7 +142,7 @@ export async function loadAccountOverviewView(
   const today = opts.today ?? yesterdayInET();
   const period = resolvePeriod(opts.period, today, seed.asOf);
 
-  const includeMarket = (opts.includeMarketData ?? true) && marketDataEnabled;
+  const includeMarket = opts.includeMarketData ?? true;
 
   if (includeMarket) {
     await enrichWithMarketData(state, seed, today);

--- a/scripts/ingest.ts
+++ b/scripts/ingest.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/db/repos/accounts";
 import { insertTransaction } from "@/lib/db/repos/transactions";
 import { insertSnapshot } from "@/lib/db/repos/positionSnapshots";
-import { setSetting, setBoolean } from "@/lib/db/repos/settings";
+import { setSetting } from "@/lib/db/repos/settings";
 import {
   identifyTransactions,
   identifyPositions,
@@ -106,7 +106,6 @@ interface PendingConfigMigration {
   seedDate: string | null;
   seedValue: number | null;
   benchmark: string | null;
-  marketDataEnabled: boolean;
 }
 
 function readPendingConfigMigration(
@@ -127,7 +126,6 @@ function readPendingConfigMigration(
       seedDate: typeof json.seedDate === "string" ? json.seedDate : null,
       seedValue: typeof json.seedValue === "number" ? json.seedValue : null,
       benchmark: typeof json.benchmark === "string" ? json.benchmark : null,
-      marketDataEnabled: !!json.marketData?.enabled,
     };
   } catch {
     return null;
@@ -146,7 +144,6 @@ function applyPendingConfigMigration(
   if (pending.benchmark) {
     setBenchmark(db, firstExternalId, pending.benchmark);
   }
-  setBoolean(db, "market_data.enabled", pending.marketDataEnabled);
   setSetting(db, "_meta.config_json_migrated", "true");
   summary.warnings.push(
     `Migrated data/config.json into account ${firstExternalId}. You can now delete data/config.json.`,

--- a/tests/scripts/ingest.test.ts
+++ b/tests/scripts/ingest.test.ts
@@ -12,7 +12,7 @@ import {
 import { listTransactionsByAccount } from "@/lib/db/repos/transactions";
 import { getEarliestSnapshotDate } from "@/lib/db/repos/positionSnapshots";
 import { setSeed } from "@/lib/db/repos/accounts";
-import { getBoolean, getSetting } from "@/lib/db/repos/settings";
+import { getSetting } from "@/lib/db/repos/settings";
 
 let testDir: string;
 
@@ -117,7 +117,6 @@ describe("ingest — config.json migration", () => {
     expect(account.seedDate).toBe("2026-01-15");
     expect(account.seedValue).toBe(12345);
     expect(account.benchmark).toBe("SPY");
-    expect(getBoolean(db, "market_data.enabled")).toBe(true);
     expect(getSetting(db, "_meta.config_json_migrated")).toBe("true");
   });
 

--- a/tests/server/account.test.ts
+++ b/tests/server/account.test.ts
@@ -5,7 +5,6 @@ import { runMigrations } from "@/lib/db/migrate";
 import { upsertAccount, setSeed } from "@/lib/db/repos/accounts";
 import { insertTransaction } from "@/lib/db/repos/transactions";
 import { insertSnapshot } from "@/lib/db/repos/positionSnapshots";
-import { setBoolean } from "@/lib/db/repos/settings";
 import { loadAccountOptionsView } from "@/lib/server/account";
 
 function makeDb() {
@@ -34,7 +33,6 @@ describe("loadAccountOptionsView", () => {
 
   it("builds a PortfolioState when transactions exist", async () => {
     const db = makeDb();
-    setBoolean(db, "market_data.enabled", false);
     const account = upsertAccount(db, { externalId: "100", label: "Demo" });
     setSeed(db, "100", "2026-01-01", 10000);
 
@@ -84,7 +82,6 @@ describe("loadAccountOptionsView", () => {
 
   it("includes a markToMarket field that is null when no held positions", async () => {
     const db = makeDb();
-    setBoolean(db, "market_data.enabled", true);
     const account = upsertAccount(db, { externalId: "300", label: "Demo3" });
     setSeed(db, "300", "2026-01-01", 10000);
     insertSnapshot(
@@ -118,7 +115,6 @@ describe("loadAccountOptionsView", () => {
     // before that date — even though chooseSeed correctly rejected the
     // snapshot as a seed.
     const db = makeDb();
-    setBoolean(db, "market_data.enabled", false);
     const account = upsertAccount(db, { externalId: "999", label: "DemoBug" });
     for (const date of ["2026-01-05", "2026-02-10", "2026-03-15", "2026-04-20"]) {
       insertTransaction(
@@ -166,7 +162,6 @@ describe("loadAccountOptionsView", () => {
 
   it("falls back to earliest snapshot for seed when no override is set", async () => {
     const db = makeDb();
-    setBoolean(db, "market_data.enabled", false);
     const account = upsertAccount(db, { externalId: "200", label: "Demo2" });
     insertSnapshot(
       db,

--- a/tests/server/accountOverview.test.ts
+++ b/tests/server/accountOverview.test.ts
@@ -5,7 +5,6 @@ import { runMigrations } from "@/lib/db/migrate";
 import { upsertAccount, setSeed } from "@/lib/db/repos/accounts";
 import { insertTransaction } from "@/lib/db/repos/transactions";
 import { insertSnapshot } from "@/lib/db/repos/positionSnapshots";
-import { setBoolean } from "@/lib/db/repos/settings";
 import { loadAccountOverviewView } from "@/lib/server/accountOverview";
 
 function makeDb() {
@@ -38,7 +37,6 @@ describe("loadAccountOverviewView", () => {
 
   it("returns ready with NAV, holdings, recent transactions, allocation", async () => {
     const db = makeDb();
-    setBoolean(db, "market_data.enabled", false);
     const account = upsertAccount(db, { externalId: "100", label: "Demo" });
     setSeed(db, "100", "2026-01-01", 10000);
     insertTransaction(
@@ -123,7 +121,6 @@ describe("loadAccountOverviewView", () => {
   it("keeps all transactions when snapshot post-dates them and no override is set", async () => {
     // Regression for issue #23.
     const db = makeDb();
-    setBoolean(db, "market_data.enabled", false);
     const account = upsertAccount(db, { externalId: "999", label: "DemoBug" });
     for (const date of ["2026-01-05", "2026-02-10", "2026-03-15", "2026-04-20"]) {
       insertTransaction(
@@ -176,7 +173,6 @@ describe("loadAccountOverviewView", () => {
 
   it("uses live snapshot mark-to-market for current NAV, ignoring options", async () => {
     const db = makeDb();
-    setBoolean(db, "market_data.enabled", false);
     const account = upsertAccount(db, { externalId: "300", label: "Demo3" });
     setSeed(db, "300", "2026-01-01", 10000);
     insertSnapshot(
@@ -242,7 +238,6 @@ describe("loadAccountOverviewView", () => {
 
   it("clamps period start to seed when period predates seed", async () => {
     const db = makeDb();
-    setBoolean(db, "market_data.enabled", false);
     const account = upsertAccount(db, { externalId: "200", label: "Demo2" });
     setSeed(db, "200", "2026-03-01", 10000);
     insertSnapshot(


### PR DESCRIPTION
## Summary
- Drops the \`market_data.enabled\` setting read in both \`lib/server/accountOverview.ts\` and \`lib/server/account.ts\`. Production always attempts to fetch live quotes / historical closes / benchmark / mark-to-market.
- Keeps \`opts.includeMarketData\` as a programmatic override (tests opt out via \`includeMarketData: false\`).
- Removes the dead \`marketData.enabled\` write path in \`scripts/ingest.ts\` (was migrating from a deprecated \`data/config.json\` shape).
- Strips \`setBoolean(db, "market_data.enabled", ...)\` calls from the loader tests — they were no-ops the moment the gate was gone.
- Removes unused \`latestSnapshot\` binding in \`accountOverview.ts\` (leftover from #28's switch to \`liveNav\`).

## Why
The setting defaulted off, was never surfaced in UI, and quietly gated everything new users actually want to see (live valuations, the SPY benchmark line, mark-to-market on Options). It was discovered while answering "where's my SPY comparison?" — answer: behind a setting nobody knew existed.

## Migration impact
Any user whose DB already has \`market_data.enabled\` stored in \`settings\` is unaffected — the value just stops being read. No DB migration. If anyone wants a privacy escape hatch later, that's a deliberate UX decision (banner + opt-out), not the current quiet default-off.

## Verified locally
- \`npm test\` — 260/260 pass
- \`npm run lint\` — clean (1 pre-existing unrelated warning)
- \`npm run typecheck\` — clean

*Co-authored by Claude*