### PR TITLE
Include options in Overview live NAV; add CLI flags to account:configure

### DIFF
--- a/app/accounts/[uuid]/overview/page.tsx
+++ b/app/accounts/[uuid]/overview/page.tsx
@@ -98,6 +98,7 @@ export default async function AccountOverviewPage({
 
         <AllocationBar
           bar={data.allocation.bar}
+          offsets={data.allocation.offsets}
           equityRows={data.allocation.equityRows}
         />
       </main>

--- a/app/components/AllocationBar.tsx
+++ b/app/components/AllocationBar.tsx
@@ -24,9 +24,11 @@ function fmtPct(n: number): string {
 
 export function AllocationBar({
   bar,
+  offsets,
   equityRows,
 }: {
   bar: AllocationSlice[];
+  offsets: AllocationSlice[];
   equityRows: EquityAllocationRow[];
 }) {
   return (
@@ -60,6 +62,18 @@ export function AllocationBar({
               <span key={s.bucket} className="inline-flex items-center gap-1">
                 <span
                   className={`inline-block w-2 h-2 rounded ${BUCKET_COLOR[s.bucket] ?? "bg-gray-400"}`}
+                />
+                {s.bucket} · {fmtPct(s.pct)} · {fmtMoney(s.value)}
+              </span>
+            ))}
+            {offsets.map((s) => (
+              <span
+                key={s.bucket}
+                className="inline-flex items-center gap-1"
+                title="Net negative market value (e.g. short options) — offsets the bar above."
+              >
+                <span
+                  className={`inline-block w-2 h-2 rounded ${BUCKET_COLOR[s.bucket] ?? "bg-gray-400"} opacity-50`}
                 />
                 {s.bucket} · {fmtPct(s.pct)} · {fmtMoney(s.value)}
               </span>

--- a/lib/server/accountOverview.ts
+++ b/lib/server/accountOverview.ts
@@ -72,7 +72,11 @@ export type AccountOverviewView =
       nav: NavStripData;
       holdings: HoldingRow[];
       transactions: Transaction[];
-      allocation: { bar: AllocationSlice[]; equityRows: EquityAllocationRow[] };
+      allocation: {
+        bar: AllocationSlice[];
+        offsets: AllocationSlice[];
+        equityRows: EquityAllocationRow[];
+      };
       sourceFiles: { transactions: string[]; positions: string[] };
       dataThroughDate: string;
       warnings: Warning[];
@@ -388,7 +392,11 @@ function buildAllocation(
   snapshotRows: PositionSnapshotRow[],
   state: PortfolioState,
   quoteMap: Record<string, Quote | null>,
-): { bar: AllocationSlice[]; equityRows: EquityAllocationRow[] } {
+): {
+  bar: AllocationSlice[];
+  offsets: AllocationSlice[];
+  equityRows: EquityAllocationRow[];
+} {
   const bucketTotals: Record<string, number> = {
     EQUITY: 0,
     OPTION: 0,
@@ -428,15 +436,15 @@ function buildAllocation(
     bucketTotals.EQUITY + bucketTotals.OPTION + bucketTotals.CASH + bucketTotals.OTHER;
   const denom = total > 0 ? total : 1;
 
-  const bar: AllocationSlice[] = (
+  const slices: AllocationSlice[] = (
     ["EQUITY", "OPTION", "CASH", "OTHER"] as const
-  )
-    .map((bucket) => ({
-      bucket,
-      value: bucketTotals[bucket],
-      pct: bucketTotals[bucket] / denom,
-    }))
-    .filter((s) => s.value > 0);
+  ).map((bucket) => ({
+    bucket,
+    value: bucketTotals[bucket],
+    pct: bucketTotals[bucket] / denom,
+  }));
+  const bar: AllocationSlice[] = slices.filter((s) => s.value > 0);
+  const offsets: AllocationSlice[] = slices.filter((s) => s.value < 0);
 
   const equityTotal = bucketTotals.EQUITY;
   const equityRows: EquityAllocationRow[] = Object.entries(equityBySymbol)
@@ -456,7 +464,7 @@ function buildAllocation(
       value: tailValue,
       pctOfEquity: equityTotal === 0 ? 0 : tailValue / equityTotal,
     });
-    return { bar, equityRows: top };
+    return { bar, offsets, equityRows: top };
   }
-  return { bar, equityRows };
+  return { bar, offsets, equityRows };
 }

--- a/lib/server/accountOverview.ts
+++ b/lib/server/accountOverview.ts
@@ -258,8 +258,7 @@ function buildNavStrip(
       : state.navSeries;
 
   // Mark-to-market live NAV from the latest snapshot wins when present —
-  // it reflects what the account is actually worth today (stocks + cash).
-  // Options market value is intentionally excluded for now.
+  // it reflects what the account is actually worth today (stocks + cash + options).
   const current =
     liveNav ?? series.at(-1)?.nav ?? state.config.seedValue;
 
@@ -322,7 +321,7 @@ function isOptionLike(assetType: string | null): boolean {
 function computeLiveNavFromSnapshot(rows: PositionSnapshotRow[]): number {
   let total = 0;
   for (const r of rows) {
-    if (isCashRow(r) || isEquityLike(r.asset_type)) {
+    if (isCashRow(r) || isEquityLike(r.asset_type) || isOptionLike(r.asset_type)) {
       total += r.market_value ?? 0;
     }
   }

--- a/scripts/account-configure.ts
+++ b/scripts/account-configure.ts
@@ -1,7 +1,9 @@
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
+import type Database from "better-sqlite3";
 import { getDb } from "@/lib/db/connection";
 import {
+  getAccountByExternalId,
   listAccounts,
   setBenchmark,
   setSeed,
@@ -97,7 +99,103 @@ async function configureOne(
   return { touched };
 }
 
+export type CliFlags = {
+  account?: string;
+  seedDate?: Choice<string>;
+  seedValue?: Choice<number>;
+  benchmark?: Choice<string>;
+};
+
+export function parseFlags(argv: string[]): CliFlags {
+  const flags: CliFlags = {};
+  for (const arg of argv) {
+    if (!arg.startsWith("--")) continue;
+    const eq = arg.indexOf("=");
+    if (eq < 0) throw new Error(`expected --key=value, got "${arg}"`);
+    const key = arg.slice(2, eq);
+    const value = arg.slice(eq + 1);
+    switch (key) {
+      case "account":
+        flags.account = value;
+        break;
+      case "seed-date":
+        flags.seedDate = parseDate(value);
+        break;
+      case "seed-value":
+        flags.seedValue = parseMoney(value);
+        break;
+      case "benchmark":
+        flags.benchmark = parseTicker(value);
+        break;
+      default:
+        throw new Error(`unknown flag --${key}`);
+    }
+  }
+  return flags;
+}
+
+export function configureNonInteractive(
+  flags: CliFlags,
+  dbOverride?: Database.Database,
+): void {
+  if (flags.account === undefined) {
+    throw new Error("--account is required for non-interactive mode");
+  }
+  if (
+    flags.seedDate === undefined &&
+    flags.seedValue === undefined &&
+    flags.benchmark === undefined
+  ) {
+    throw new Error(
+      "non-interactive mode requires at least one of --seed-date, --seed-value, --benchmark",
+    );
+  }
+
+  const db = dbOverride ?? getDb();
+  const account = getAccountByExternalId(db, flags.account);
+  if (!account) {
+    throw new Error(
+      `account with external_id="${flags.account}" not found — run \`npm run ingest\` first or check the id`,
+    );
+  }
+
+  if (flags.seedDate !== undefined || flags.seedValue !== undefined) {
+    const dateChoice = flags.seedDate ?? { kind: "keep" };
+    const valueChoice = flags.seedValue ?? { kind: "keep" };
+    const nextDate =
+      dateChoice.kind === "set"
+        ? dateChoice.value
+        : dateChoice.kind === "clear"
+          ? null
+          : account.seedDate;
+    const nextValue =
+      valueChoice.kind === "set"
+        ? valueChoice.value
+        : valueChoice.kind === "clear"
+          ? null
+          : account.seedValue;
+    setSeed(db, account.externalId, nextDate, nextValue);
+  }
+
+  if (flags.benchmark !== undefined) {
+    const next =
+      flags.benchmark.kind === "set" ? flags.benchmark.value : null;
+    setBenchmark(db, account.externalId, next);
+  }
+
+  const after = getAccountByExternalId(db, flags.account);
+  console.log(`Updated ${account.label} (external_id ${account.externalId}):`);
+  console.log(`  ${after ? fmtCurrent(after) : "(not found after update)"}`);
+}
+
 async function main() {
+  const flags = parseFlags(process.argv.slice(2));
+
+  if (Object.keys(flags).length > 0) {
+    configureNonInteractive(flags);
+    return;
+  }
+
   const db = getDb();
   const accounts = listAccounts(db);
 

--- a/tests/scripts/account-configure.test.ts
+++ b/tests/scripts/account-configure.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import path from "node:path";
+import { runMigrations } from "@/lib/db/migrate";
+import {
+  upsertAccount,
+  getAccountByExternalId,
+} from "@/lib/db/repos/accounts";
+import {
+  parseFlags,
+  configureNonInteractive,
+} from "@/scripts/account-configure";
+
+function makeDb(): Database.Database {
+  const db = new Database(":memory:");
+  runMigrations(db, path.join(process.cwd(), "db", "migrations"));
+  return db;
+}
+
+describe("parseFlags", () => {
+  it("returns an empty object when no flags are passed", () => {
+    expect(parseFlags([])).toEqual({});
+  });
+
+  it("parses --account, --seed-date, --seed-value, --benchmark", () => {
+    const flags = parseFlags([
+      "--account=520",
+      "--seed-date=2026-01-15",
+      "--seed-value=12345",
+      "--benchmark=SPY",
+    ]);
+    expect(flags.account).toBe("520");
+    expect(flags.seedDate).toEqual({ kind: "set", value: "2026-01-15" });
+    expect(flags.seedValue).toEqual({ kind: "set", value: 12345 });
+    expect(flags.benchmark).toEqual({ kind: "set", value: "SPY" });
+  });
+
+  it("treats --seed-date=- as a clear", () => {
+    const flags = parseFlags(["--account=1", "--seed-date=-"]);
+    expect(flags.seedDate).toEqual({ kind: "clear" });
+  });
+
+  it("rejects unknown flags", () => {
+    expect(() => parseFlags(["--bogus=1"])).toThrow(/unknown flag/);
+  });
+
+  it("rejects malformed flags missing =", () => {
+    expect(() => parseFlags(["--account"])).toThrow(/expected --key=value/);
+  });
+
+  it("rejects bad seed-date format", () => {
+    expect(() => parseFlags(["--seed-date=01/15/2026"])).toThrow(
+      /expected YYYY-MM-DD/,
+    );
+  });
+
+  it("rejects negative seed-value", () => {
+    expect(() => parseFlags(["--seed-value=-100"])).toThrow(
+      /expected non-negative number/,
+    );
+  });
+});
+
+describe("configureNonInteractive", () => {
+  it("requires --account", () => {
+    const db = makeDb();
+    expect(() =>
+      configureNonInteractive({ seedDate: { kind: "set", value: "2026-01-01" } }, db),
+    ).toThrow(/--account is required/);
+  });
+
+  it("requires at least one update flag", () => {
+    const db = makeDb();
+    expect(() => configureNonInteractive({ account: "100" }, db)).toThrow(
+      /at least one of --seed-date, --seed-value, --benchmark/,
+    );
+  });
+
+  it("errors clearly when the account is unknown", () => {
+    const db = makeDb();
+    expect(() =>
+      configureNonInteractive(
+        {
+          account: "999",
+          seedDate: { kind: "set", value: "2026-01-01" },
+          seedValue: { kind: "set", value: 1000 },
+        },
+        db,
+      ),
+    ).toThrow(/external_id="999" not found/);
+  });
+
+  it("sets seed_date and seed_value on a known account", () => {
+    const db = makeDb();
+    upsertAccount(db, { externalId: "520", label: "Demo" });
+
+    configureNonInteractive(
+      {
+        account: "520",
+        seedDate: { kind: "set", value: "2026-01-15" },
+        seedValue: { kind: "set", value: 12345 },
+      },
+      db,
+    );
+
+    const after = getAccountByExternalId(db, "520");
+    expect(after?.seedDate).toBe("2026-01-15");
+    expect(after?.seedValue).toBe(12345);
+  });
+
+  it("sets benchmark independently", () => {
+    const db = makeDb();
+    upsertAccount(db, { externalId: "520", label: "Demo" });
+
+    configureNonInteractive(
+      { account: "520", benchmark: { kind: "set", value: "SPY" } },
+      db,
+    );
+
+    expect(getAccountByExternalId(db, "520")?.benchmark).toBe("SPY");
+  });
+
+  it("clears seed_date and seed_value when both are set to clear", () => {
+    const db = makeDb();
+    const account = upsertAccount(db, { externalId: "520", label: "Demo" });
+    // Seed it first.
+    configureNonInteractive(
+      {
+        account: "520",
+        seedDate: { kind: "set", value: "2026-01-01" },
+        seedValue: { kind: "set", value: 5000 },
+      },
+      db,
+    );
+    expect(getAccountByExternalId(db, "520")?.seedDate).toBe("2026-01-01");
+
+    configureNonInteractive(
+      {
+        account: "520",
+        seedDate: { kind: "clear" },
+        seedValue: { kind: "clear" },
+      },
+      db,
+    );
+
+    const after = getAccountByExternalId(db, account.externalId);
+    expect(after?.seedDate).toBeNull();
+    expect(after?.seedValue).toBeNull();
+  });
+
+  it("only updates fields that are provided (preserves the rest)", () => {
+    const db = makeDb();
+    upsertAccount(db, { externalId: "520", label: "Demo" });
+    configureNonInteractive(
+      {
+        account: "520",
+        seedDate: { kind: "set", value: "2026-01-01" },
+        seedValue: { kind: "set", value: 5000 },
+        benchmark: { kind: "set", value: "SPY" },
+      },
+      db,
+    );
+
+    // Now only update the benchmark.
+    configureNonInteractive(
+      { account: "520", benchmark: { kind: "set", value: "QQQ" } },
+      db,
+    );
+
+    const after = getAccountByExternalId(db, "520");
+    expect(after?.seedDate).toBe("2026-01-01");
+    expect(after?.seedValue).toBe(5000);
+    expect(after?.benchmark).toBe("QQQ");
+  });
+});

--- a/tests/server/accountOverview.test.ts
+++ b/tests/server/accountOverview.test.ts
@@ -234,6 +234,25 @@ describe("loadAccountOverviewView", () => {
     if (result?.kind !== "ready") throw new Error("expected ready");
     // 7500 (equity) + 2000 (cash) + (-150) (short option) = 9350.
     expect(result.nav.current).toBe(9350);
+
+    // The negative OPTION bucket must surface as an offset (never in the
+    // bar), so the geometry stays clean while the chip row makes the
+    // -1.6% short-option contribution visible.
+    const barBuckets = result.allocation.bar.map((s) => s.bucket);
+    expect(barBuckets).toEqual(expect.arrayContaining(["EQUITY", "CASH"]));
+    expect(barBuckets).not.toContain("OPTION");
+
+    const optionOffset = result.allocation.offsets.find(
+      (s) => s.bucket === "OPTION",
+    );
+    expect(optionOffset).toBeDefined();
+    expect(optionOffset?.value).toBe(-150);
+    expect(optionOffset?.pct).toBeCloseTo(-150 / 9350, 5);
+
+    const totalPct =
+      result.allocation.bar.reduce((a, s) => a + s.pct, 0) +
+      result.allocation.offsets.reduce((a, s) => a + s.pct, 0);
+    expect(totalPct).toBeCloseTo(1, 5);
   });
 
   it("clamps period start to seed when period predates seed", async () => {

--- a/tests/server/accountOverview.test.ts
+++ b/tests/server/accountOverview.test.ts
@@ -171,7 +171,7 @@ describe("loadAccountOverviewView", () => {
     expect(result.warnings.some((w) => w.kind === "MissingSeed")).toBe(true);
   });
 
-  it("uses live snapshot mark-to-market for current NAV, ignoring options", async () => {
+  it("uses live snapshot mark-to-market for current NAV, including options", async () => {
     const db = makeDb();
     const account = upsertAccount(db, { externalId: "300", label: "Demo3" });
     setSeed(db, "300", "2026-01-01", 10000);
@@ -207,7 +207,7 @@ describe("loadAccountOverviewView", () => {
       },
       "snap.csv",
     );
-    // An option row that should be excluded from the live NAV (for now).
+    // Short option with negative market value — included in live NAV.
     insertSnapshot(
       db,
       account.id,
@@ -232,8 +232,8 @@ describe("loadAccountOverviewView", () => {
       includeMarketData: false,
     });
     if (result?.kind !== "ready") throw new Error("expected ready");
-    // 7500 (equity) + 2000 (cash). Option row's -150 is excluded.
-    expect(result.nav.current).toBe(9500);
+    // 7500 (equity) + 2000 (cash) + (-150) (short option) = 9350.
+    expect(result.nav.current).toBe(9350);
   });
 
   it("clamps period start to seed when period predates seed", async () => {


### PR DESCRIPTION
Bundles two small fixes:

## Closes #29 — option contract market value in Overview live NAV

`computeLiveNavFromSnapshot` was filtering rows to cash + equity only. PR #28 had deferred options pending a UX call on contingent-liability semantics; treating the snapshot's signed `market_value` as today's-liquidation contribution (the same convention the Allocation OPTION bucket already uses) is the cleanest fix.

A short put with `market_value: -150` now reduces NAV by 150 — matching the snapshot's view of cost-to-close — rather than being silently dropped. The test that previously asserted exclusion now asserts inclusion (NAV = 7500 + 2000 + (-150) = 9350).

## Closes #21 — `account:configure` CLI flags

The core bug (single-snapshot accounts filtering out all history) was already fixed by PR #24 and the `MissingSeed` banner by PR #26. The remaining acceptance criterion was the non-interactive form of `account:configure`:

```
npm run account:configure -- --account=520 --seed-date=2026-01-15 --seed-value=12345
```

Adds flag parsing alongside the existing interactive flow. When any flag is present the script runs non-interactively against a single account; otherwise it falls back to the existing prompt loop. `--account` is required; at least one of `--seed-date` / `--seed-value` / `--benchmark` must be supplied. The `-` clear sentinel works in flag form just like in the interactive prompt.

`parseFlags` and `configureNonInteractive` are exported so they're unit-testable. 14 new tests in `tests/scripts/account-configure.test.ts` cover flag parsing, validation errors, single-field updates, multi-field updates, clears, and the unknown-account path.

## Test plan

- [x] `npm test` — 280/280 pass (14 new for account-configure)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [x] CLI smoke: bad flag, missing `--account`, unknown `--account` all fail with clear messages
- [ ] Open Overview for an account with a short option in the latest snapshot — verify the NAV now reflects the contract value
- [ ] Run `npm run account:configure -- --account=<id> --seed-date=2026-01-01 --seed-value=10000` against a fresh account — verify the values land in the DB and the Overview banner clears
- [ ] Run the same against a bogus `--account` — verify the error message points at `npm run ingest`

Closes #29
Closes #21

*Co-authored by Claude*