### PR TITLE
home: total NAV strip + account grid + stale badges (closes #6, #7)

### DIFF
--- a/app/components/AccountCard.tsx
+++ b/app/components/AccountCard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Sparkline } from "@/app/components/Sparkline";
 import { formatCurrency } from "@/lib/util/money";
+import { formatRelativeFromNow } from "@/lib/util/relativeTime";
 import type { AccountSummary } from "@/lib/server/home";
 
 type Props = {
@@ -8,9 +9,13 @@ type Props = {
 };
 
 export function AccountCard({ summary }: Props) {
-  const { account, nav, twr, navSeries, hasData, clamped } = summary;
+  const { account, nav, twr, navSeries, hasData, clamped, staleness } = summary;
   const hasTwr = twr !== null;
   const positive = hasTwr ? twr! >= 0 : null;
+  const lastUpdated = formatRelativeFromNow(
+    account.lastSeenAt,
+    staleness.referenceTime,
+  );
 
   return (
     <Link
@@ -19,8 +24,18 @@ export function AccountCard({ summary }: Props) {
     >
       <div className="flex items-start justify-between gap-3 mb-2">
         <div className="min-w-0">
-          <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
-            {account.label}
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+              {account.label}
+            </span>
+            {staleness.isStale && (
+              <span
+                className="text-[9px] uppercase tracking-wide font-semibold px-1.5 py-0.5 rounded bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+                title={`No new export in ${staleness.daysSinceLastSeen} days`}
+              >
+                Stale
+              </span>
+            )}
           </div>
           <div className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
             ···{account.externalId}
@@ -52,8 +67,17 @@ export function AccountCard({ summary }: Props) {
         positive={positive}
         className="w-full h-9"
       />
+      <div
+        className={`text-[10px] mt-1 ${
+          staleness.isStale
+            ? "text-amber-600 dark:text-amber-400"
+            : "text-gray-400 dark:text-gray-500"
+        }`}
+      >
+        Last updated {lastUpdated}
+      </div>
       {clamped && (
-        <div className="text-[10px] text-amber-600 dark:text-amber-400 mt-1">
+        <div className="text-[10px] text-amber-600 dark:text-amber-400 mt-0.5">
           period clamped to earliest data
         </div>
       )}

--- a/app/components/AccountCard.tsx
+++ b/app/components/AccountCard.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { Sparkline } from "@/app/components/Sparkline";
+import { formatCurrency } from "@/lib/util/money";
+import type { AccountSummary } from "@/lib/server/home";
+
+type Props = {
+  summary: AccountSummary;
+};
+
+export function AccountCard({ summary }: Props) {
+  const { account, nav, twr, navSeries, hasData, clamped } = summary;
+  const hasTwr = twr !== null;
+  const positive = hasTwr ? twr! >= 0 : null;
+
+  return (
+    <Link
+      href={`/accounts/${account.uuid}/overview`}
+      className="block rounded-lg border border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-4 hover:border-gray-300 dark:hover:border-neutral-700 hover:shadow-sm transition"
+    >
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <div className="min-w-0">
+          <div className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+            {account.label}
+          </div>
+          <div className="text-[10px] text-gray-500 dark:text-gray-400 mt-0.5">
+            ···{account.externalId}
+          </div>
+        </div>
+        <div
+          className={`text-xs font-semibold tabular-nums ${
+            hasTwr
+              ? positive
+                ? "text-emerald-600"
+                : "text-red-600"
+              : "text-gray-400 dark:text-gray-500"
+          }`}
+        >
+          {hasTwr
+            ? `${positive ? "+" : ""}${(twr! * 100).toFixed(2)}%`
+            : hasData
+              ? "—"
+              : "no data"}
+        </div>
+      </div>
+      <div className="text-2xl font-bold tabular-nums mb-2">
+        {formatCurrency(nav)}
+      </div>
+      <Sparkline
+        points={navSeries}
+        width={240}
+        height={36}
+        positive={positive}
+        className="w-full h-9"
+      />
+      {clamped && (
+        <div className="text-[10px] text-amber-600 dark:text-amber-400 mt-1">
+          period clamped to earliest data
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/app/components/HomePeriodSelector.tsx
+++ b/app/components/HomePeriodSelector.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import type { PeriodKey } from "@/lib/server/period";
+
+const PERIODS: PeriodKey[] = ["1M", "3M", "YTD", "1Y", "All"];
+
+type Props = {
+  active: PeriodKey;
+};
+
+export function HomePeriodSelector({ active }: Props) {
+  return (
+    <div className="flex items-center gap-1">
+      {PERIODS.map((p) => {
+        const isActive = p === active;
+        return (
+          <Link
+            key={p}
+            href={p === "1M" ? "/" : `/?period=${p}`}
+            className={`px-2 py-1 rounded text-xs ${
+              isActive
+                ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
+                : "bg-gray-100 dark:bg-neutral-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-neutral-700"
+            }`}
+          >
+            {p}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/components/Sparkline.tsx
+++ b/app/components/Sparkline.tsx
@@ -1,0 +1,75 @@
+import type { NavPoint } from "@/lib/model/types";
+
+type Props = {
+  points: NavPoint[];
+  width?: number;
+  height?: number;
+  positive?: boolean | null;
+  className?: string;
+};
+
+export function Sparkline({
+  points,
+  width = 120,
+  height = 32,
+  positive = null,
+  className,
+}: Props) {
+  if (points.length < 2) {
+    return (
+      <div
+        className={`text-[10px] text-gray-400 dark:text-gray-500 ${className ?? ""}`}
+        style={{ width, height, display: "flex", alignItems: "center", justifyContent: "center" }}
+      >
+        —
+      </div>
+    );
+  }
+
+  const navs = points.map((p) => p.nav);
+  const min = Math.min(...navs);
+  const max = Math.max(...navs);
+  const span = max - min || 1;
+  const firstMs = Date.parse(points[0].date);
+  const lastMs = Date.parse(points.at(-1)!.date);
+  const xRange = Math.max(1, lastMs - firstMs);
+
+  const stroke =
+    positive === true
+      ? "#059669"
+      : positive === false
+        ? "#dc2626"
+        : "#6b7280";
+  const fillId = `spark-fill-${stroke.slice(1)}`;
+
+  const path = points
+    .map((p, i) => {
+      const x = ((Date.parse(p.date) - firstMs) / xRange) * width;
+      const y = height - ((p.nav - min) / span) * height;
+      return `${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+
+  const areaPath = `${path} L${width},${height} L0,${height} Z`;
+
+  return (
+    <svg
+      className={className}
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      role="img"
+      aria-label="NAV trend"
+    >
+      <defs>
+        <linearGradient id={fillId} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0" stopColor={stroke} stopOpacity="0.18" />
+          <stop offset="1" stopColor={stroke} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={areaPath} fill={`url(#${fillId})`} />
+      <path d={path} stroke={stroke} strokeWidth={1.5} fill="none" />
+    </svg>
+  );
+}

--- a/app/components/TotalNavStrip.tsx
+++ b/app/components/TotalNavStrip.tsx
@@ -1,0 +1,67 @@
+import { Sparkline } from "@/app/components/Sparkline";
+import { HomePeriodSelector } from "@/app/components/HomePeriodSelector";
+import { formatCurrency } from "@/lib/util/money";
+import type { HomeView } from "@/lib/server/home";
+
+type Props = {
+  view: HomeView;
+};
+
+export function TotalNavStrip({ view }: Props) {
+  const { total, period, accounts } = view;
+  const hasTwr = total.twr !== null;
+  const positive = hasTwr ? total.twr! >= 0 : null;
+  const accountCount = accounts.length;
+
+  return (
+    <section className="rounded-lg border border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5 mb-6">
+      <div className="flex items-start justify-between gap-4 mb-3">
+        <div>
+          <div className="text-[11px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Total NAV
+          </div>
+          <div className="text-3xl font-bold tabular-nums">
+            {formatCurrency(total.nav)}
+          </div>
+          <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+            {accountCount} account{accountCount === 1 ? "" : "s"} ·{" "}
+            {period.requestedStart} → {period.requestedEnd}
+          </div>
+        </div>
+        <div className="flex flex-col items-end gap-2">
+          <HomePeriodSelector active={period.key} />
+          <div
+            className={`text-sm font-semibold tabular-nums ${
+              hasTwr
+                ? positive
+                  ? "text-emerald-600"
+                  : "text-red-600"
+                : "text-gray-400 dark:text-gray-500"
+            }`}
+          >
+            {hasTwr
+              ? `${positive ? "+" : ""}${(total.twr! * 100).toFixed(2)}%`
+              : "—"}
+            <span className="text-[10px] font-normal text-gray-500 dark:text-gray-400 ml-1">
+              {period.key} TWR
+            </span>
+          </div>
+        </div>
+      </div>
+      <div className="w-full">
+        <Sparkline
+          points={total.navSeries}
+          width={1200}
+          height={64}
+          positive={positive}
+          className="w-full h-16"
+        />
+      </div>
+      {hasTwr && (
+        <div className="text-[10px] text-gray-400 dark:text-gray-500 mt-1">
+          NAV-weighted across accounts.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,78 +1,48 @@
-import Link from "next/link";
-import { loadHome } from "@/lib/server/home";
+import { loadHomeView } from "@/lib/server/home";
 import { OnboardingCard } from "@/app/components/OnboardingCard";
+import { TotalNavStrip } from "@/app/components/TotalNavStrip";
+import { AccountCard } from "@/app/components/AccountCard";
+import type { PeriodKey } from "@/lib/server/period";
 
 export const dynamic = "force-dynamic";
 
-export default async function Home() {
-  const { accounts, loadedAt } = await loadHome();
+const VALID: ReadonlySet<PeriodKey> = new Set(["1M", "3M", "YTD", "1Y", "All"]);
 
-  if (accounts.length === 0) {
-    return <OnboardingCard dataDir="data/" />;
+// `/` defaults to 1M per spec, distinct from the shared YTD default.
+function homePeriodKey(input: string | undefined): PeriodKey {
+  if (input && (VALID as Set<string>).has(input)) return input as PeriodKey;
+  return "1M";
+}
+
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ period?: string }>;
+}) {
+  const { period: periodParam } = await searchParams;
+  const period = homePeriodKey(periodParam);
+
+  const view = await loadHomeView({ period });
+
+  if (view.accounts.length === 0) {
+    return (
+      <main className="min-h-screen p-6 max-w-7xl mx-auto">
+        <OnboardingCard dataDir="data/" />
+      </main>
+    );
   }
 
   return (
     <main className="min-h-screen p-6 max-w-7xl mx-auto">
-      <header className="rounded-lg border border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-5 py-4 mb-6 flex items-baseline justify-between">
-        <div>
-          <div className="text-xl font-bold">Accounts</div>
-          <div className="text-xs text-gray-500 dark:text-gray-400">
-            {accounts.length} account{accounts.length === 1 ? "" : "s"} ingested
-          </div>
-        </div>
-        <div className="text-xs text-gray-500 dark:text-gray-400">
-          Last refresh {new Date(loadedAt).toLocaleTimeString()}
-        </div>
-      </header>
-
-      <ul className="space-y-2">
-        {accounts.map((a) => (
-          <li
-            key={a.uuid}
-            className="rounded-lg border border-gray-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 px-5 py-4"
-          >
-            <div className="flex items-baseline justify-between gap-4">
-              <div className="min-w-0">
-                <Link
-                  href={`/accounts/${a.uuid}/overview`}
-                  className="text-base font-semibold text-gray-900 dark:text-gray-100 hover:underline"
-                >
-                  {a.label}
-                </Link>
-                <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                  Last seen {new Date(a.lastSeenAt).toLocaleDateString()}
-                </div>
-              </div>
-              <div className="flex items-center gap-3 text-sm">
-                <Link
-                  href={`/accounts/${a.uuid}/overview`}
-                  className="text-blue-600 dark:text-blue-400 hover:underline"
-                >
-                  Overview
-                </Link>
-                <Link
-                  href={`/accounts/${a.uuid}/options`}
-                  className="text-blue-600 dark:text-blue-400 hover:underline"
-                >
-                  Options
-                </Link>
-                <Link
-                  href={`/accounts/${a.uuid}/trades`}
-                  className="text-blue-600 dark:text-blue-400 hover:underline"
-                >
-                  Trades
-                </Link>
-                <Link
-                  href={`/accounts/${a.uuid}/transactions`}
-                  className="text-blue-600 dark:text-blue-400 hover:underline"
-                >
-                  Transactions
-                </Link>
-              </div>
-            </div>
-          </li>
+      <TotalNavStrip view={view} />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {view.accounts.map((summary) => (
+          <AccountCard key={summary.account.uuid} summary={summary} />
         ))}
-      </ul>
+      </div>
+      <div className="text-[10px] text-gray-400 dark:text-gray-500 mt-6 text-right">
+        Last refresh {new Date(view.loadedAt).toLocaleTimeString()}
+      </div>
     </main>
   );
 }

--- a/lib/server/home.ts
+++ b/lib/server/home.ts
@@ -8,8 +8,13 @@ import { navSeriesFromSnapshots } from "@/lib/model/metrics/navSeries";
 import { computeTwr } from "@/lib/model/metrics/twr";
 import { resolvePeriod, type PeriodKey } from "@/lib/server/period";
 import { effectiveToday } from "@/lib/util/dates";
+import { daysBetweenIso } from "@/lib/util/relativeTime";
 import type { Transaction } from "@/lib/csv/types";
 import type { NavPoint } from "@/lib/model/types";
+
+// Cards older than this read as "stale" — exports for non-primary accounts
+// may be infrequent and we don't want a stale Roth IRA card to look fresh.
+export const STALE_THRESHOLD_DAYS = 7;
 
 export type AccountSummary = {
   account: Account;
@@ -20,6 +25,11 @@ export type AccountSummary = {
   effectiveStart: { date: string; nav: number } | null;
   effectiveEnd: { date: string; nav: number } | null;
   clamped: boolean;
+  staleness: {
+    daysSinceLastSeen: number;
+    isStale: boolean;
+    referenceTime: string;
+  };
 };
 
 export type HomeView = {
@@ -41,6 +51,9 @@ export type LoadHomeOpts = {
   db?: Database.Database;
   period?: PeriodKey;
   today?: string;
+  // Wall-clock reference for staleness ("are exports recent?"). Distinct from
+  // `today`, which is snapshot-anchored for TWR calculations. Defaults to now.
+  now?: string;
 };
 
 type LoadedAccount = {
@@ -56,6 +69,7 @@ export async function loadHomeView(opts: LoadHomeOpts = {}): Promise<HomeView> {
   const accounts = listAccounts(db);
   const periodKey: PeriodKey = opts.period ?? "1M";
   const loadedAt = new Date().toISOString();
+  const now = opts.now ?? loadedAt;
 
   const loaded: LoadedAccount[] = accounts.map((account) => {
     const txRows = listTransactionsByAccount(db, account.id);
@@ -88,7 +102,7 @@ export async function loadHomeView(opts: LoadHomeOpts = {}): Promise<HomeView> {
   const globalPeriod = resolvePeriod(periodKey, today, earliestAcrossAccounts);
 
   const summaries: AccountSummary[] = loaded.map((l) =>
-    summarizeAccount(l, periodKey, today),
+    summarizeAccount(l, periodKey, today, now),
   );
 
   const totalNav = summaries.reduce((s, a) => s + a.nav, 0);
@@ -115,7 +129,18 @@ function summarizeAccount(
   l: LoadedAccount,
   periodKey: PeriodKey,
   today: string,
+  now: string,
 ): AccountSummary {
+  const daysSinceLastSeen = Math.max(
+    0,
+    daysBetweenIso(l.account.lastSeenAt, now),
+  );
+  const staleness = {
+    daysSinceLastSeen,
+    isStale: daysSinceLastSeen > STALE_THRESHOLD_DAYS,
+    referenceTime: now,
+  };
+
   const hasData = l.transactions.length > 0 || l.navSeries.length > 0;
   if (!hasData) {
     return {
@@ -127,6 +152,7 @@ function summarizeAccount(
       effectiveStart: null,
       effectiveEnd: null,
       clamped: false,
+      staleness,
     };
   }
 
@@ -165,6 +191,7 @@ function summarizeAccount(
     effectiveStart: twrResult.effectiveStart,
     effectiveEnd: twrResult.effectiveEnd,
     clamped: period.clampedToSeed || twrResult.clamped,
+    staleness,
   };
 }
 

--- a/lib/server/home.ts
+++ b/lib/server/home.ts
@@ -1,24 +1,221 @@
 import type Database from "better-sqlite3";
 import { getDb } from "@/lib/db/connection";
 import { listAccounts, type Account } from "@/lib/db/repos/accounts";
+import { listTransactionsByAccount } from "@/lib/db/repos/transactions";
+import { getAllSnapshotsByAccount } from "@/lib/db/repos/positionSnapshots";
+import { transactionFromRow } from "@/lib/model/fromDb";
+import { navSeriesFromSnapshots } from "@/lib/model/metrics/navSeries";
+import { computeTwr } from "@/lib/model/metrics/twr";
+import { resolvePeriod, type PeriodKey } from "@/lib/server/period";
+import { effectiveToday } from "@/lib/util/dates";
+import type { Transaction } from "@/lib/csv/types";
+import type { NavPoint } from "@/lib/model/types";
 
-export type HomeData = {
-  accounts: Account[];
+export type AccountSummary = {
+  account: Account;
+  hasData: boolean;
+  nav: number;
+  navSeries: NavPoint[];
+  twr: number | null;
+  effectiveStart: { date: string; nav: number } | null;
+  effectiveEnd: { date: string; nav: number } | null;
+  clamped: boolean;
+};
+
+export type HomeView = {
+  accounts: AccountSummary[];
+  total: {
+    nav: number;
+    twr: number | null;
+    navSeries: NavPoint[];
+  };
+  period: {
+    key: PeriodKey;
+    requestedStart: string;
+    requestedEnd: string;
+  };
   loadedAt: string;
 };
 
-export interface LoadHomeOpts {
+export type LoadHomeOpts = {
   db?: Database.Database;
-}
+  period?: PeriodKey;
+  today?: string;
+};
 
-export async function loadHome(opts: LoadHomeOpts = {}): Promise<HomeData> {
+type LoadedAccount = {
+  account: Account;
+  transactions: Transaction[];
+  navSeries: NavPoint[];
+  earliestSnap: string | null;
+  latestSnap: string | null;
+};
+
+export async function loadHomeView(opts: LoadHomeOpts = {}): Promise<HomeView> {
   const db = opts.db ?? getDb();
   const accounts = listAccounts(db);
-  return { accounts, loadedAt: new Date().toISOString() };
+  const periodKey: PeriodKey = opts.period ?? "1M";
+  const loadedAt = new Date().toISOString();
+
+  const loaded: LoadedAccount[] = accounts.map((account) => {
+    const txRows = listTransactionsByAccount(db, account.id);
+    const snapshotRows = getAllSnapshotsByAccount(db, account.id);
+    const navSeries = navSeriesFromSnapshots(snapshotRows);
+    return {
+      account,
+      transactions: txRows.map(transactionFromRow),
+      navSeries,
+      earliestSnap: navSeries[0]?.date ?? null,
+      latestSnap: navSeries.at(-1)?.date ?? null,
+    };
+  });
+
+  const globalLatest =
+    loaded
+      .map((l) => l.latestSnap)
+      .filter((d): d is string => d !== null)
+      .sort()
+      .at(-1) ?? null;
+  const today = opts.today ?? effectiveToday(globalLatest);
+  // For the strip's window we want the union of all account histories, so
+  // anchor the period's seed on the earliest data date across accounts. Falls
+  // back to today when no account has any data yet.
+  const earliestAcrossAccounts =
+    loaded
+      .map((l) => l.earliestSnap)
+      .filter((d): d is string => d !== null)
+      .sort()[0] ?? today;
+  const globalPeriod = resolvePeriod(periodKey, today, earliestAcrossAccounts);
+
+  const summaries: AccountSummary[] = loaded.map((l) =>
+    summarizeAccount(l, periodKey, today),
+  );
+
+  const totalNav = summaries.reduce((s, a) => s + a.nav, 0);
+  const totalTwr = navWeightedTwr(summaries);
+  const totalNavSeries = buildTotalNavSeries(
+    loaded.map((l) => l.navSeries),
+    globalPeriod.start,
+    globalPeriod.end,
+  );
+
+  return {
+    accounts: summaries,
+    total: { nav: totalNav, twr: totalTwr, navSeries: totalNavSeries },
+    period: {
+      key: periodKey,
+      requestedStart: globalPeriod.start,
+      requestedEnd: globalPeriod.end,
+    },
+    loadedAt,
+  };
+}
+
+function summarizeAccount(
+  l: LoadedAccount,
+  periodKey: PeriodKey,
+  today: string,
+): AccountSummary {
+  const hasData = l.transactions.length > 0 || l.navSeries.length > 0;
+  if (!hasData) {
+    return {
+      account: l.account,
+      hasData: false,
+      nav: 0,
+      navSeries: [],
+      twr: null,
+      effectiveStart: null,
+      effectiveEnd: null,
+      clamped: false,
+    };
+  }
+
+  const seedAsOf = l.account.seedDate ?? l.earliestSnap ?? today;
+  const period = resolvePeriod(periodKey, today, seedAsOf);
+
+  const seed =
+    l.account.seedDate !== null && l.account.seedValue !== null
+      ? { date: l.account.seedDate, value: l.account.seedValue }
+      : null;
+
+  const twrResult = computeTwr({
+    navPoints: l.navSeries,
+    transactions: l.transactions,
+    period: { from: period.start, to: period.end },
+    seed,
+  });
+
+  const within = l.navSeries.filter(
+    (p) => p.date >= period.start && p.date <= period.end,
+  );
+  // Prepend the chosen anchor (seed or first snapshot in window) so the card
+  // sparkline begins at the same point the TWR chain begins.
+  const sparkline =
+    twrResult.effectiveStart &&
+    (within.length === 0 || within[0].date !== twrResult.effectiveStart.date)
+      ? [twrResult.effectiveStart, ...within]
+      : within;
+
+  return {
+    account: l.account,
+    hasData: true,
+    nav: l.navSeries.at(-1)?.nav ?? 0,
+    navSeries: sparkline,
+    twr: twrResult.twr,
+    effectiveStart: twrResult.effectiveStart,
+    effectiveEnd: twrResult.effectiveEnd,
+    clamped: period.clampedToSeed || twrResult.clamped,
+  };
+}
+
+// NAV-weighted average of per-account TWRs. Weight is each account's effective
+// start NAV (the value being earned-against). Accounts without a valid TWR or
+// without a positive start NAV contribute nothing.
+function navWeightedTwr(summaries: AccountSummary[]): number | null {
+  let weightedSum = 0;
+  let totalWeight = 0;
+  for (const s of summaries) {
+    if (s.twr === null || s.effectiveStart === null) continue;
+    if (s.effectiveStart.nav <= 0) continue;
+    weightedSum += s.twr * s.effectiveStart.nav;
+    totalWeight += s.effectiveStart.nav;
+  }
+  return totalWeight === 0 ? null : weightedSum / totalWeight;
+}
+
+function buildTotalNavSeries(
+  navSeriesByAccount: NavPoint[][],
+  start: string,
+  end: string,
+): NavPoint[] {
+  const dateSet = new Set<string>();
+  for (const series of navSeriesByAccount) {
+    for (const p of series) {
+      if (p.date >= start && p.date <= end) dateSet.add(p.date);
+    }
+  }
+  if (dateSet.size === 0) return [];
+  const dates = Array.from(dateSet).sort();
+  return dates.map((date) => {
+    let total = 0;
+    for (const series of navSeriesByAccount) {
+      total += navAtOrBefore(series, date);
+    }
+    return { date, nav: total };
+  });
+}
+
+function navAtOrBefore(series: NavPoint[], date: string): number {
+  let last = 0;
+  for (const p of series) {
+    if (p.date <= date) last = p.nav;
+    else break;
+  }
+  return last;
 }
 
 export async function loadAccounts(
-  opts: LoadHomeOpts = {},
+  opts: { db?: Database.Database } = {},
 ): Promise<Account[]> {
   const db = opts.db ?? getDb();
   return listAccounts(db);

--- a/lib/util/relativeTime.ts
+++ b/lib/util/relativeTime.ts
@@ -1,0 +1,28 @@
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+const MONTH = 30 * DAY;
+const YEAR = 365 * DAY;
+
+export function daysBetweenIso(fromIso: string, toIso: string): number {
+  return Math.floor((Date.parse(toIso) - Date.parse(fromIso)) / DAY);
+}
+
+export function formatRelativeFromNow(thenIso: string, nowIso: string): string {
+  const diff = Date.parse(nowIso) - Date.parse(thenIso);
+  if (Number.isNaN(diff)) return "—";
+  if (diff < MINUTE) return "just now";
+  if (diff < HOUR) return plural(Math.floor(diff / MINUTE), "minute");
+  if (diff < DAY) return plural(Math.floor(diff / HOUR), "hour");
+  if (diff < 2 * DAY) return "yesterday";
+  if (diff < WEEK) return plural(Math.floor(diff / DAY), "day");
+  if (diff < MONTH) return plural(Math.floor(diff / WEEK), "week");
+  if (diff < YEAR) return plural(Math.floor(diff / MONTH), "month");
+  return plural(Math.floor(diff / YEAR), "year");
+}
+
+function plural(n: number, unit: string): string {
+  return `${n} ${unit}${n === 1 ? "" : "s"} ago`;
+}

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -3,7 +3,7 @@ import Database from "better-sqlite3";
 import path from "node:path";
 import { runMigrations } from "@/lib/db/migrate";
 import { upsertAccount } from "@/lib/db/repos/accounts";
-import { loadHome } from "@/lib/server/home";
+import { loadHomeView } from "@/lib/server/home";
 
 function makeDb() {
   const db = new Database(":memory:");
@@ -11,12 +11,14 @@ function makeDb() {
   return db;
 }
 
-describe("loadHome (integration)", () => {
+describe("loadHomeView (integration)", () => {
   it("returns an empty accounts list when no accounts exist", async () => {
     const db = makeDb();
-    const { accounts, loadedAt } = await loadHome({ db });
-    expect(accounts).toEqual([]);
-    expect(typeof loadedAt).toBe("string");
+    const view = await loadHomeView({ db, today: "2026-05-01" });
+    expect(view.accounts).toEqual([]);
+    expect(view.total.nav).toBe(0);
+    expect(view.total.twr).toBeNull();
+    expect(typeof view.loadedAt).toBe("string");
   });
 
   it("returns ingested accounts in deterministic order", async () => {
@@ -24,14 +26,14 @@ describe("loadHome (integration)", () => {
     upsertAccount(db, { externalId: "100", label: "Demo Brokerage" });
     upsertAccount(db, { externalId: "200", label: "Demo Roth" });
 
-    const { accounts } = await loadHome({ db });
+    const { accounts } = await loadHomeView({ db, today: "2026-05-01" });
     expect(accounts).toHaveLength(2);
-    const externalIds = accounts.map((a) => a.externalId).sort();
+    const externalIds = accounts.map((a) => a.account.externalId).sort();
     expect(externalIds).toEqual(["100", "200"]);
     for (const a of accounts) {
-      expect(typeof a.uuid).toBe("string");
-      expect(a.uuid.length).toBeGreaterThan(0);
-      expect(typeof a.lastSeenAt).toBe("string");
+      expect(typeof a.account.uuid).toBe("string");
+      expect(a.account.uuid.length).toBeGreaterThan(0);
+      expect(a.hasData).toBe(false);
     }
   });
 });

--- a/tests/server/home.test.ts
+++ b/tests/server/home.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import Database from "better-sqlite3";
+import path from "node:path";
+import { runMigrations } from "@/lib/db/migrate";
+import { upsertAccount, setSeed } from "@/lib/db/repos/accounts";
+import { insertSnapshot } from "@/lib/db/repos/positionSnapshots";
+import { insertTransaction } from "@/lib/db/repos/transactions";
+import { loadHomeView } from "@/lib/server/home";
+
+function makeDb() {
+  const db = new Database(":memory:");
+  runMigrations(db, path.join(process.cwd(), "db", "migrations"));
+  return db;
+}
+
+function snap(
+  db: Database.Database,
+  accountId: number,
+  asOf: string,
+  symbol: string,
+  marketValue: number,
+) {
+  insertSnapshot(
+    db,
+    accountId,
+    {
+      asOf,
+      symbol,
+      description: null,
+      quantity: 1,
+      price: marketValue,
+      marketValue,
+      costBasis: marketValue,
+      assetType: "equity",
+      raw: {},
+    },
+    `${asOf}.csv`,
+  );
+}
+
+describe("loadHomeView", () => {
+  it("returns an empty view with zero total when no accounts exist", async () => {
+    const db = makeDb();
+    const view = await loadHomeView({ db, today: "2026-05-01" });
+    expect(view.accounts).toHaveLength(0);
+    expect(view.total.nav).toBe(0);
+    expect(view.total.twr).toBeNull();
+    expect(view.total.navSeries).toEqual([]);
+    expect(view.period.key).toBe("1M");
+  });
+
+  it("marks accounts with no transactions or snapshots as hasData=false", async () => {
+    const db = makeDb();
+    upsertAccount(db, { externalId: "100", label: "Empty" });
+
+    const view = await loadHomeView({ db, today: "2026-05-01" });
+    expect(view.accounts).toHaveLength(1);
+    expect(view.accounts[0].hasData).toBe(false);
+    expect(view.accounts[0].nav).toBe(0);
+    expect(view.accounts[0].twr).toBeNull();
+    expect(view.total.nav).toBe(0);
+  });
+
+  it("computes per-account TWR over the requested period and exposes a sparkline", async () => {
+    const db = makeDb();
+    const acct = upsertAccount(db, { externalId: "200", label: "TWR" });
+    setSeed(db, "200", "2026-01-01", 10000);
+    snap(db, acct.id, "2026-01-01", "ACME", 10000);
+    snap(db, acct.id, "2026-04-01", "ACME", 11000);
+    snap(db, acct.id, "2026-04-30", "ACME", 12100);
+
+    const view = await loadHomeView({ db, period: "All", today: "2026-04-30" });
+    expect(view.accounts).toHaveLength(1);
+    const summary = view.accounts[0];
+    expect(summary.hasData).toBe(true);
+    expect(summary.nav).toBe(12100);
+    // 10k → 12.1k = 21%
+    expect(summary.twr).toBeCloseTo(0.21, 4);
+    expect(summary.navSeries.length).toBeGreaterThanOrEqual(2);
+    expect(summary.navSeries.at(-1)?.nav).toBe(12100);
+  });
+
+  it("aggregates total NAV across accounts and computes a NAV-weighted total TWR", async () => {
+    const db = makeDb();
+    const a = upsertAccount(db, { externalId: "100", label: "A" });
+    setSeed(db, "100", "2026-01-01", 10000);
+    snap(db, a.id, "2026-01-01", "A1", 10000);
+    snap(db, a.id, "2026-04-30", "A1", 11000); // +10%
+
+    const b = upsertAccount(db, { externalId: "200", label: "B" });
+    setSeed(db, "200", "2026-01-01", 30000);
+    snap(db, b.id, "2026-01-01", "B1", 30000);
+    snap(db, b.id, "2026-04-30", "B1", 33600); // +12%
+
+    const view = await loadHomeView({ db, period: "All", today: "2026-04-30" });
+    expect(view.accounts).toHaveLength(2);
+    expect(view.total.nav).toBe(11000 + 33600);
+    // weighted: (0.10 * 10k + 0.12 * 30k) / 40k = 0.115
+    expect(view.total.twr).toBeCloseTo(0.115, 4);
+  });
+
+  it("forward-fills the total NAV series across accounts with disjoint snapshot dates", async () => {
+    const db = makeDb();
+    const a = upsertAccount(db, { externalId: "100", label: "A" });
+    setSeed(db, "100", "2026-01-01", 100);
+    snap(db, a.id, "2026-01-01", "A1", 100);
+    snap(db, a.id, "2026-03-01", "A1", 150);
+
+    const b = upsertAccount(db, { externalId: "200", label: "B" });
+    setSeed(db, "200", "2026-01-01", 200);
+    snap(db, b.id, "2026-02-01", "B1", 200);
+    snap(db, b.id, "2026-04-01", "B1", 250);
+
+    const view = await loadHomeView({ db, period: "All", today: "2026-04-01" });
+    const series = view.total.navSeries;
+    const byDate = Object.fromEntries(series.map((p) => [p.date, p.nav]));
+
+    // 2026-01-01: only A reported (100); B has no snapshot yet → 0.
+    expect(byDate["2026-01-01"]).toBe(100);
+    // 2026-02-01: A still 100 (forward-filled), B starts at 200 → 300.
+    expect(byDate["2026-02-01"]).toBe(300);
+    // 2026-03-01: A jumps to 150, B forward-filled at 200 → 350.
+    expect(byDate["2026-03-01"]).toBe(350);
+    // 2026-04-01: A forward-filled at 150, B at 250 → 400.
+    expect(byDate["2026-04-01"]).toBe(400);
+  });
+
+  it("clamps the per-account period when the account's data does not reach the period start", async () => {
+    const db = makeDb();
+    const acct = upsertAccount(db, { externalId: "100", label: "Late" });
+    // No seed; account first appears in March, but user asks for 1Y.
+    snap(db, acct.id, "2026-03-01", "X", 1000);
+    snap(db, acct.id, "2026-04-30", "X", 1100);
+
+    const view = await loadHomeView({
+      db,
+      period: "1Y",
+      today: "2026-04-30",
+    });
+    const summary = view.accounts[0];
+    expect(summary.clamped).toBe(true);
+    expect(summary.effectiveStart?.date).toBe("2026-03-01");
+    expect(summary.twr).toBeCloseTo(0.1, 4);
+  });
+
+  it("returns null TWR for an account with insufficient snapshots in the period", async () => {
+    const db = makeDb();
+    const acct = upsertAccount(db, { externalId: "100", label: "Sparse" });
+    setSeed(db, "100", "2026-04-30", 1000);
+    snap(db, acct.id, "2026-04-30", "X", 1000);
+
+    const view = await loadHomeView({
+      db,
+      period: "1M",
+      today: "2026-04-30",
+    });
+    expect(view.accounts[0].twr).toBeNull();
+    // No valid TWR contributors → total TWR is also null.
+    expect(view.total.twr).toBeNull();
+    // But NAV still reported.
+    expect(view.total.nav).toBe(1000);
+  });
+
+  it("uses 1M as the default period", async () => {
+    const db = makeDb();
+    upsertAccount(db, { externalId: "100", label: "Demo" });
+    const view = await loadHomeView({ db, today: "2026-05-01" });
+    expect(view.period.key).toBe("1M");
+  });
+
+  it("treats accounts with snapshots but no transactions as having data", async () => {
+    const db = makeDb();
+    const acct = upsertAccount(db, { externalId: "100", label: "SnapOnly" });
+    snap(db, acct.id, "2026-04-30", "X", 1234);
+
+    const view = await loadHomeView({ db, today: "2026-04-30" });
+    expect(view.accounts[0].hasData).toBe(true);
+    expect(view.accounts[0].nav).toBe(1234);
+  });
+
+  it("recognizes external transfers as flows and excludes them from TWR", async () => {
+    const db = makeDb();
+    const acct = upsertAccount(db, { externalId: "200", label: "Flow" });
+    setSeed(db, "200", "2026-01-01", 10000);
+    snap(db, acct.id, "2026-01-01", "ACME", 10000);
+    // Mid-period $5k deposit; ending NAV reflects it.
+    insertTransaction(
+      db,
+      acct.id,
+      {
+        tradeDate: "2026-02-15",
+        actionCanonical: "TRANSFER_IN",
+        actionRaw: "MoneyLink Transfer",
+        symbol: null,
+        description: null,
+        quantity: null,
+        price: null,
+        fees: null,
+        amount: 5000,
+        raw: {},
+      },
+      "tx.csv",
+    );
+    snap(db, acct.id, "2026-04-30", "ACME", 16000);
+
+    const view = await loadHomeView({
+      db,
+      period: "All",
+      today: "2026-04-30",
+    });
+    const t = view.accounts[0].twr;
+    expect(t).not.toBeNull();
+    // Without flow handling: (16000-10000)/10000 = 0.60. With flow handling
+    // the deposit's denominator weight reduces the effective return to
+    // somewhere near (16000 - 10000 - 5000) / (10000 + weighted 5000) ≈ ~9-10%.
+    // Confirm the engine actually netted the flow out (TWR < raw NAV change).
+    expect(t!).toBeLessThan(0.60);
+    expect(t!).toBeGreaterThan(0);
+  });
+});

--- a/tests/server/home.test.ts
+++ b/tests/server/home.test.ts
@@ -5,7 +5,7 @@ import { runMigrations } from "@/lib/db/migrate";
 import { upsertAccount, setSeed } from "@/lib/db/repos/accounts";
 import { insertSnapshot } from "@/lib/db/repos/positionSnapshots";
 import { insertTransaction } from "@/lib/db/repos/transactions";
-import { loadHomeView } from "@/lib/server/home";
+import { loadHomeView, STALE_THRESHOLD_DAYS } from "@/lib/server/home";
 
 function makeDb() {
   const db = new Database(":memory:");
@@ -166,6 +166,32 @@ describe("loadHomeView", () => {
     upsertAccount(db, { externalId: "100", label: "Demo" });
     const view = await loadHomeView({ db, today: "2026-05-01" });
     expect(view.period.key).toBe("1M");
+  });
+
+  it("flags accounts as stale when last_seen_at is more than 7 days old", async () => {
+    const db = makeDb();
+    upsertAccount(db, { externalId: "100", label: "Fresh" });
+    upsertAccount(db, { externalId: "200", label: "Old" });
+    // Backdate the second account's last_seen_at directly.
+    db.prepare("UPDATE accounts SET last_seen_at = ? WHERE external_id = ?").run(
+      "2026-04-01T00:00:00.000Z",
+      "200",
+    );
+
+    const view = await loadHomeView({
+      db,
+      now: "2026-05-01T00:00:00.000Z",
+      today: "2026-05-01",
+    });
+    const byLabel = Object.fromEntries(
+      view.accounts.map((a) => [a.account.label, a]),
+    );
+    expect(byLabel["Fresh"].staleness.isStale).toBe(false);
+    expect(byLabel["Fresh"].staleness.daysSinceLastSeen).toBeLessThanOrEqual(
+      STALE_THRESHOLD_DAYS,
+    );
+    expect(byLabel["Old"].staleness.isStale).toBe(true);
+    expect(byLabel["Old"].staleness.daysSinceLastSeen).toBe(30);
   });
 
   it("treats accounts with snapshots but no transactions as having data", async () => {

--- a/tests/util/relativeTime.test.ts
+++ b/tests/util/relativeTime.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  daysBetweenIso,
+  formatRelativeFromNow,
+} from "@/lib/util/relativeTime";
+
+describe("daysBetweenIso", () => {
+  it("returns 0 for the same instant", () => {
+    expect(
+      daysBetweenIso("2026-04-30T12:00:00Z", "2026-04-30T12:00:00Z"),
+    ).toBe(0);
+  });
+
+  it("counts whole days regardless of clock-time", () => {
+    expect(
+      daysBetweenIso("2026-04-25T00:00:00Z", "2026-04-30T23:00:00Z"),
+    ).toBe(5);
+  });
+
+  it("returns negative when then is in the future", () => {
+    expect(
+      daysBetweenIso("2026-05-01T00:00:00Z", "2026-04-30T00:00:00Z"),
+    ).toBe(-1);
+  });
+});
+
+describe("formatRelativeFromNow", () => {
+  const now = "2026-05-01T12:00:00Z";
+  const cases: Array<[string, string]> = [
+    ["2026-05-01T11:59:30Z", "just now"],
+    ["2026-05-01T11:55:00Z", "5 minutes ago"],
+    ["2026-05-01T08:00:00Z", "4 hours ago"],
+    ["2026-04-30T11:00:00Z", "yesterday"],
+    ["2026-04-28T12:00:00Z", "3 days ago"],
+    ["2026-04-15T12:00:00Z", "2 weeks ago"],
+    ["2026-02-15T12:00:00Z", "2 months ago"],
+    ["2025-04-01T12:00:00Z", "1 year ago"],
+    ["2024-05-01T12:00:00Z", "2 years ago"],
+  ];
+
+  for (const [then, expected] of cases) {
+    it(`formats ${then} → "${expected}"`, () => {
+      expect(formatRelativeFromNow(then, now)).toBe(expected);
+    });
+  }
+
+  it("handles unparseable input gracefully", () => {
+    expect(formatRelativeFromNow("nonsense", now)).toBe("—");
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the placeholder list at `/` with the spec'd dashboard from
`docs/superpowers/specs/2026-04-27-schwab-lens-design.md` (the `/` section), and bundles in #7 (per-account stale-data indicator) since it lives entirely in the same view.

### #6 — Total NAV strip + account grid

- **Total NAV strip:** aggregate NAV across accounts, NAV-weighted TWR for the selected period, full-width sparkline, and `1M`/`3M`/`YTD`/`1Y`/`All` selector. Default period is `1M`; `?period=<key>` survives navigation and uses the same convention as `/accounts/[uuid]/overview`.
- **Account grid:** card per account showing label, current NAV, period TWR, sparkline, and a "period clamped" hint when the account's data doesn't span the full window. Each card links to `/accounts/[uuid]/overview`.
- **Onboarding fallback:** zero accounts still renders the existing `OnboardingCard`.

### #7 — Last-updated + stale badge

- Each card shows `Last updated <relative>` sourced from `accounts.last_seen_at` (touched on every `npm run ingest`).
- `last_seen_at` older than **7 days** flips a `Stale` pill in the card header and tints the timestamp amber.
- 7d rationale: most secondary accounts (IRA, 401k roll-over) get fresh exports weekly when the user batches them. A month-stale read could quietly look authoritative; a one-week guard catches that without false-positives during normal cadence.

### Math (#6)

- Per-account TWR uses the same `computeTwr` engine as `/accounts/[uuid]/overview`, anchored on `today = effectiveToday(latest snapshot across accounts)`.
- Global window for the strip's NAV series anchors on the earliest snapshot across accounts so `All` spans the union of histories rather than collapsing to today.
- Total NAV series = union of in-window snapshot dates, each account's NAV forward-filled (0 before its first snapshot), summed.
- Total TWR = NAV-weighted average of per-account TWRs (weight = effective-start NAV); null when no account has a valid TWR.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (only the pre-existing `mkdirSync` warning in `tests/market/quotes.test.ts`)
- [x] `npm test` — 49 files, 352 tests passing (10 new in `tests/server/home.test.ts`, 11 new in `tests/util/relativeTime.test.ts`)
- [x] `npm run build` succeeds
- [x] `npm run dev` and `curl /` against a populated DB renders strip + card with the right NAV / TWR / dates / "Last updated 5 hours ago"; status 200 for every period variant (`1M`/`3M`/`YTD`/`1Y`/`All`).
- [ ] Manual: visit `/` after `npm run db:reset` — confirm `OnboardingCard` shows.
- [ ] Manual: visit `/` with multiple ingested accounts — confirm strip totals match the per-card sum and the period selector swaps both the strip and all cards consistently.
- [ ] Manual: click a card → lands on `/accounts/<uuid>/overview`.
- [ ] Manual stale check: ` UPDATE accounts SET last_seen_at = '2025-01-01' WHERE external_id = '…';` in `data/portfolio.db` → that account's card shows the `Stale` pill and an amber-tinted "Last updated …" line; reload after `npm run ingest` and confirm the badge clears.

## Notes

- Cross-account analytics (allocation pie, contribution, concentration warnings) are out of scope here; F2 (#9) tracks them.
- List-only `/` view is filed as F3 (#10) for the record.
- Targets `multi-account`, not `main`.

*Co-authored by Claude*